### PR TITLE
Migrate to testcontainers from docker compose

### DIFF
--- a/pfi-mock-impl/build.gradle
+++ b/pfi-mock-impl/build.gradle
@@ -13,6 +13,8 @@ application {
     mainClass = 'io.tbd.tbdex.pfi_mock_impl.Main'
 }
 
+def testContainersVersion = '1.17.2'
+
 dependencies {
     implementation project(':lib')
     implementation 'com.google.inject:guice:5.1.0'
@@ -33,6 +35,10 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+
+    testImplementation "org.testcontainers:testcontainers:${testContainersVersion}"
+    testImplementation "org.testcontainers:junit-jupiter:${testContainersVersion}"
+    testImplementation "org.testcontainers:mysql:${testContainersVersion}"
 }
 
 test {

--- a/pfi-mock-impl/src/main/java/io/tbd/tbdex/pfi_mock_impl/payments/PaymentProcessor.java
+++ b/pfi-mock-impl/src/main/java/io/tbd/tbdex/pfi_mock_impl/payments/PaymentProcessor.java
@@ -46,8 +46,7 @@ public class PaymentProcessor {
     Ask ask = messageThread.getAsk();
     Preconditions.checkNotNull(ask);
 
-    String body = parser.toJson(settlementDetails.body);
-    PaymentProcessorRequest request = parser.fromJson(body, PaymentProcessorRequest.class);
+    PaymentProcessorRequest request = parser.fromJson(settlementDetails.body, PaymentProcessorRequest.class);
 
     // Register Bank Account with Circle.
     // TODO: Do not store bank account in our database

--- a/pfi-mock-impl/src/main/java/io/tbd/tbdex/pfi_mock_impl/store/HibernateUtil.java
+++ b/pfi-mock-impl/src/main/java/io/tbd/tbdex/pfi_mock_impl/store/HibernateUtil.java
@@ -9,6 +9,12 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.service.ServiceRegistry;
 
 public class HibernateUtil {
+  public static final int DB_PORT = 3307;
+  public static final int MYSQL_DEFAULT_PORT = 3306;
+  public static final String DB_NAME = "tbdex";
+  public static final String DB_USER = "root";
+  public static final String DB_PASS = "tbdev";
+
   private static SessionFactory sessionFactory;
 
   public static SessionFactory getSessionFactory() {
@@ -19,9 +25,9 @@ public class HibernateUtil {
         // Hibernate settings equivalent to hibernate.cfg.xml's properties
         Properties settings = new Properties();
         settings.put(Environment.DRIVER, "com.mysql.jdbc.Driver");
-        settings.put(Environment.URL, "jdbc:mysql://localhost:3307/tbdex");
-        settings.put(Environment.USER, "root");
-        settings.put(Environment.PASS, "tbdev");
+        settings.put(Environment.URL, String.format("jdbc:mysql://localhost:%s/%s", DB_PORT, DB_NAME));
+        settings.put(Environment.USER, DB_USER);
+        settings.put(Environment.PASS, DB_PASS);
         settings.put(Environment.DIALECT, "org.hibernate.dialect.MySQL5Dialect");
         settings.put(Environment.HBM2DDL_AUTO, "update");
 

--- a/pfi-mock-impl/src/test/java/io/tbd/tbdex/pfi_mock_impl/payments/PaymentProcessorTest.java
+++ b/pfi-mock-impl/src/test/java/io/tbd/tbdex/pfi_mock_impl/payments/PaymentProcessorTest.java
@@ -1,43 +1,81 @@
 package io.tbd.tbdex.pfi_mock_impl.payments;
 
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Ports;
+import com.google.gson.JsonElement;
 import com.squareup.protos.tbd.pfi.PaymentProcessorRequest;
 import io.tbd.tbdex.pfi_mock_impl.TestBase;
 import io.tbd.tbdex.pfi_mock_impl.TestHelper;
+import io.tbd.tbdex.pfi_mock_impl.store.HibernateUtil;
 import io.tbd.tbdex.protocol.core.JsonParser;
 import io.tbd.tbdex.protocol.core.Message;
 import io.tbd.tbdex.protocol.core.MessageThreadStore;
 import io.tbd.tbdex.protocol.messages.Ask;
 import io.tbd.tbdex.protocol.messages.SettlementDetails;
-import java.math.BigDecimal;
-import javax.inject.Inject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
+import javax.inject.Inject;
+import java.math.BigDecimal;
+import java.util.function.Consumer;
+
+@Testcontainers
 public class PaymentProcessorTest extends TestBase {
-  @Inject MessageThreadStore threadStore;
-  @Inject PaymentProcessor paymentProcessor;
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-  @Test
-  @DisplayName("runs without error")
-  void happyPath() {
-    String threadToken = "thid";
-    Message message1 = new Message.Builder("mid", threadToken, "pfi", "alice")
-        .build(new Ask("USDC", BigDecimal.valueOf(100), "USDC"));
-    threadStore.addMessageToThread(message1);
+    private @Inject MessageThreadStore threadStore;
+    private @Inject PaymentProcessor paymentProcessor;
 
-    PaymentProcessorRequest request = new PaymentProcessorRequest.Builder()
-        .account_number(TestHelper.PAYMENT_INSTRUMENT.account_number)
-        .routing_number(TestHelper.PAYMENT_INSTRUMENT.routing_number)
-        .bank_address(TestHelper.BANK_ADDRESS)
-        .billing_details(TestHelper.BILLING_DETAILS)
-        .wallet_address("123")
-        .email_address("123")
-        .build();
+    private final int hostPort = HibernateUtil.DB_PORT;
+    private final int containerExposedPort = HibernateUtil.MYSQL_DEFAULT_PORT;
+    private final PortBinding staticBinding = new PortBinding(
+            Ports.Binding.bindPort(hostPort),
+            new ExposedPort(containerExposedPort)
+    );
+    private final Consumer<CreateContainerCmd> containerBinding = e -> e.withPortBindings(staticBinding);
 
-    String body = JsonParser.getParser().toJson(request);
+    @Container
+    private final GenericContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:5.7"))
+            .withDatabaseName(HibernateUtil.DB_NAME)
+            .withUsername(HibernateUtil.DB_USER)
+            .withPassword(HibernateUtil.DB_PASS)
+            .withCreateContainerCmdModifier(containerBinding)
+            .withClasspathResourceMapping("migrations/", "/docker-entrypoint-initdb.d", BindMode.READ_WRITE)
+            .withLogConsumer(new Slf4jLogConsumer(logger));
 
-    SettlementDetails settlementDetails = new SettlementDetails(JsonParser.getParser().toJsonTree(body));
+    @Test
+    @DisplayName("runs without error")
+    void happyPath() {
+        logger.debug("MySql database container: {}", mysql.getContainerName());
 
-    paymentProcessor.process(settlementDetails, threadToken);
-  }
+        String threadToken = "thid";
+        Message message1 = new Message.Builder("mid", threadToken, "pfi", "alice")
+                .build(new Ask("USDC", BigDecimal.valueOf(100), "USDC"));
+        threadStore.addMessageToThread(message1);
+
+        PaymentProcessorRequest request = new PaymentProcessorRequest.Builder()
+                .account_number(TestHelper.PAYMENT_INSTRUMENT.account_number)
+                .routing_number(TestHelper.PAYMENT_INSTRUMENT.routing_number)
+                .bank_address(TestHelper.BANK_ADDRESS)
+                .billing_details(TestHelper.BILLING_DETAILS)
+                .wallet_address("123")
+                .email_address("123")
+                .build();
+
+        JsonElement body = JsonParser.getParser().toJsonTree(request);
+        SettlementDetails settlementDetails = new SettlementDetails(body);
+
+        paymentProcessor.process(settlementDetails, threadToken);
+    }
 }


### PR DESCRIPTION
I'd like to propose using [testcontainers](https://testcontainers.org) in unit tests. 
Testcontainers has multiple advantages in comparison to docker-compose:
 - a docker container being created in a unit test, no need for executing external commands.
 - it's more flexible in many ways (dynamic port bindings, creating containers using parameters from java source code, etc)
 - it manages the container's lifecycle in a unit test and cleans up all docker resources after the test finishes (disposable infrastructure approach)

This PR migrates PaymentProcessorTest class to testcontainers