### PR TITLE
updated readme to add and update tbdex message types

### DIFF
--- a/protocol/README.md
+++ b/protocol/README.md
@@ -29,12 +29,13 @@ The `body` of each message can be any of the following message types
 | field            | data type | required | description                                                                                          |
 | ---------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------- |
 | `id` | string    | Y        | A unique identifier for this offering.|
+| `description` | string    | Y        | Brief description of what is being offered.|
 | `pair` | string    | Y        | The currency pair being offered, in the format of `basecurrency_countercurrency`.|
 | `unitPrice` | string    | Y        | Price of 1 unit of base currency denominated in counter currency.|
 | `baseFee`   | string       | N        | Optional base fee associated with this offering, regardless of which Payment Instruments are used |
 | `min`   | string       | Y        | Minimum amount of counter currency that the counterparty (Alice) must submit in order to qualify for this offering.|
 | `max`   | string       | Y        | Maximum amount of counter currency that the counterparty (Alice) can submit in order to qualify for this offering.|
-| `presentationRequest`   | PresentationRequest    | Y        |  PresentationRequest which describes the credential needed to choose this offer.|
+| `presentationRequestJwt`   | string    | Y        |  PresentationRequest in JWT format which describes the credential needed to choose this offer.|
 | `payinInstruments`   | list[PaymentInstrument]    | Y        |  A list of payment instruments the counterparty (Alice) can choose to send payment to the PFI from in order to qualify for this offering.|
 | `payoutInstruments`   | list[PaymentInstrument]    | Y        |  A list of payment instruments the counterparty (Alice) can choose to receive payment from the PFI in order to qualify for this offering.|
 
@@ -50,12 +51,13 @@ There's an explicit directionality baked into the `pair` naming convention, whic
 PFI -> Alice: "Here's what I can offer if you want to buy BTC with USD, and here are the constraints of my offer, in terms of how much you can buy, what credentials I need from you, and what payment instruments you can use to pay me, and what payment instruments I can use to pay you."
 ```json
 {
+  "description": "Buy BTC with USD, much wow!",
   "pair": "BTC_USD",
   "unitPrice": 27000.00,
   "baseFee": 1.00,
   "min": 10.00,
   "max": 100.00,
-  "presentationRequest": { /* Presentation Request for KYC VC */ },
+  "presentationRequestJwt": "/* Presentation Request for KYC VC in JWT string format */",
   "payinInstruments": [{
       "kind": "DEBIT_CARD",
       "fee": {
@@ -101,11 +103,11 @@ Alice -> PFI: "OK, that offering looks good. I want a Quote against that Offerin
 | `rfqId`          | string         | Y        | The identifier of the RFQ request this quote is responding to.|
 | `quoteId`          | string         | Y        | The identifier of this quote.|
 | `expiryTime`     | datetime         | Y        | When this quote expires.|
-| `totalFee`     | string         | Y        | Total fee (base + paymentInstrument specific) included in quote|
-| `amount`     | string         | Y        | Amount of base currency that the PFI is willing to send|
-| `paymentPresentationRequest`     | PresentationRequest   | Y        | PresentationRequest that describes the payment instrument needed to execute this Quote (with payment kind indicated per the RFQ) |
+| `totalFee`     | string         | Y        | Total fee (base + paymentInstrument specific) included in quote in counter currency.|
+| `amount`     | string         | Y        | Amount of base currency that the PFI is willing to sell in exchange for counter currency `amount` in the original RFQ|
+| `paymentPresentationRequestJwt`     | string   | Y        | PresentationRequest that describes the payment instrument needed to execute this Quote (with payment kind indicated per the RFQ) |
 
-PFI -> Alice: "OK, here's your Quote that describes how much base currency you will receive based on your RFQ. Here's the total fee associated with the payment instruments you selected, and here is the presentationRequest you can use to send in your payment instruments in, when you're ready to execute the Quote."
+PFI -> Alice: "OK, here's your Quote that describes how much base currency you will receive based on your RFQ. Here's the total fee associated with the payment instruments you selected, and here is the paymentPresentationRequestJwt you can use to send in your payment instruments in, when you're ready to execute the Quote."
 ```json
 {
   "rfqId": "1",
@@ -113,7 +115,7 @@ PFI -> Alice: "OK, here's your Quote that describes how much base currency you w
   "expiryTime": "2023-04-14T12:12:12Z",
   "totalFee": 1.00,
   "amount": 0.000383,
-  "paymentPresentationRequest": { /* Payin and payout instrument presentation requests in one */ }
+  "paymentPresentationRequestJwt": "/* Payin and payout instrument presentation requests in one, in JWT string format */"
 }
 
 ```

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -31,7 +31,7 @@ The `body` of each message can be any of the following message types
 | `id` | string    | Y        | A unique identifier for this offering.|
 | `pair` | string    | Y        | The currency pair being offered, in the format of `basecurrency_countercurrency`.|
 | `unitPrice` | string    | Y        | Price of 1 unit of base currency denominated in counter currency.|
-| `fee`   | string       | Y        | Base fee associated with this offering |
+| `baseFee`   | string       | N        | Optional base fee associated with this offering, regardless of which Payment Instruments are used |
 | `min`   | string       | Y        | Minimum amount of counter currency that the counterparty (Alice) must submit in order to qualify for this offering.|
 | `max`   | string       | Y        | Maximum amount of counter currency that the counterparty (Alice) can submit in order to qualify for this offering.|
 | `presentationRequest`   | PresentationRequest    | Y        |  PresentationRequest which describes the credential needed to choose this offer.|
@@ -45,26 +45,25 @@ There's an explicit directionality baked into the `pair` naming convention, whic
 | field            | data type | required | description                                                                                          |
 | ---------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------- |
 | `kind` | enum    | Y        | Type of payment instrument (i.e. `DEBIT_CARD`, `BITCOIN_ADDRESS`)|
-| `fee` | string    | N        | Optional fee associated with using this kind of payment instrument.|
-| `presentationRequest` | PresentationRequest    | Y        | PresentationRequest which describes the credential needed to use this kind of payment instrument.|
+| `fee` | object    | N        | Optional fee associated with using this kind of payment instrument.|
 
 PFI -> Alice: "Here's what I can offer if you want to buy BTC with USD, and here are the constraints of my offer, in terms of how much you can buy, what credentials I need from you, and what payment instruments you can use to pay me, and what payment instruments I can use to pay you."
 ```json
 {
   "pair": "BTC_USD",
   "unitPrice": 27000.00,
-  "fee": 1.00,
+  "baseFee": 1.00,
   "min": 10.00,
   "max": 100.00,
-  "presentationRequest": { ... },
+  "presentationRequest": { /* Presentation Request for KYC VC */ },
   "payinInstruments": [{
       "kind": "DEBIT_CARD",
-      "fee": 1,
-      "presentationRequest": {},
+      "fee": {
+        "flatFee": 1.00
+      }
   }],
   "payoutInstruments": [{
-      "kind": "BTC_ADDRESS",
-      "presentationRequest": {}
+      "kind": "BTC_ADDRESS"
   }]
 }
 ```
@@ -86,11 +85,11 @@ Alice -> PFI: "OK, that offering looks good. I want a Quote against that Offerin
   "rfqId": "1",
   "pair": "BTC_USD",
   "amount": 10.00,
-  "verifiablePresentation": { ... },
-  "payin_instrument": {
+  "verifiablePresentation": { /* Alice's KYC VC in Verifiable Presentation format */ },
+  "payinInstrument": {
       "kind": "DEBIT_CARD"
   },
-  "payout_instrument": {
+  "payoutInstrument": {
       "kind": "BTC_ADDRESS"
   }
 }
@@ -114,7 +113,7 @@ PFI -> Alice: "OK, here's your Quote that describes how much base currency you w
   "expiryTime": "2023-04-14T12:12:12Z",
   "totalFee": 1.00,
   "amount": 0.000383,
-  "paymentPresentationRequest": { ...}
+  "paymentPresentationRequest": { /* Payin and payout instrument presentation requests in one */ }
 }
 
 ```
@@ -132,7 +131,7 @@ Alice -> PFI: "Let's execute the Quote and turn it into an Order. Here are my pa
 {
     "orderId": 32432,
     "quoteId": 2,
-    "paymentVerifiablePresentation": { ...}
+    "paymentVerifiablePresentation": { /* Alice's Debit Card and Bitcoin VC in Verifiable Presentation format  */}
 }
 ```
 

--- a/protocol/tbdex_schema_examples.js
+++ b/protocol/tbdex_schema_examples.js
@@ -1,10 +1,11 @@
 let offering = {
+  "description": "Buy BTC with USD, much wow!",
   "pair": "BTC_USD",
   "unitPrice": 27000.00,
   "baseFee": 1.00,
   "min": 10.00,
   "max": 100.00,
-  "presentationRequest": { },
+  "presentationRequestJwt": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa3NpcEpqd1RZb2Y2YXRiQnJreDVienJTTVhyUVVkZkJlOGFqcmhaY3JieFhuI3o2TWtzaXBKandUWW9mNmF0YkJya3g1YnpyU01YclFVZGZCZThhanJoWmNyYnhYbiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2ODYwOTE2NTksImlhdCI6MTY4NjA5MTY1OSwiaXNzIjoiZGlkOmtleTp6Nk1rc2lwSmp3VFlvZjZhdGJCcmt4NWJ6clNNWHJRVWRmQmU4YWpyaFpjcmJ4WG4iLCJqdGkiOiJhNWFkYzM2OC1lYWM3LTQ0ZTMtYjlhMi04ZDE3MTY1MmFjYzUiLCJuYmYiOjE2ODYwOTE2NTksInByZXNlbnRhdGlvbl9kZWZpbml0aW9uIjp7ImlkIjoiM2E2NjM0OTgtMjNjYy00NWQ3LThjNzYtZTJhZWUxMzdmYTdkIiwiaW5wdXRfZGVzY3JpcHRvcnMiOlt7ImNvbnN0cmFpbnRzIjp7ImZpZWxkcyI6W3sibmFtZSI6IkZ1bGwgTmFtZSIsInBhdGgiOlsiJC5mdWxsTmFtZSIsIiQudmMuZnVsbE5hbWUiXX0seyJuYW1lIjoiRGF0ZSBvZiBCaXJ0aCIsInBhdGgiOlsiJC5kYXRlT2ZCaXJ0aCIsIiQudmMuZGF0ZU9mQmlydGgiLCIkLmRvYiIsIiQudmMuZG9iIl19XX0sImlkIjoiMCIsInB1cnBvc2UiOiJLWUMgVkMifV0sIm5hbWUiOiJLWUMgVkMgUHJlc2VudGF0aW9uIERlZmluaXRpb24iLCJwdXJwb3NlIjoiUHJvdmlkZSBpbmZvIHNvIHdlIGtub3cgeW91IGFyZSBub3QgYSBiYWRkaWUifX0.bL8br3_5jkHZF6XAFtoVa4opBw_zfBtYYEynxA9jD8uvZ1tJC47uQ8aG_Ds6odFaZNgY3tf0uWFcrK9S-0MIDw",
   "payinInstruments": [{
       "kind": "DEBIT_CARD",
       "fee": {
@@ -21,10 +22,10 @@ let rfq = {
   "pair": "BTC_USD",
   "amount": 10.00,
   "verifiablePresentation": { },
-  "payin_instrument": {
+  "payinInstrument": {
       "kind": "DEBIT_CARD"
   },
-  "payout_instrument": {
+  "payoutInnstrument": {
       "kind": "BTC_ADDRESS"
   }
 }
@@ -35,7 +36,7 @@ let quote = {
   "expiryTime": "2023-04-14T12:12:12Z",
   "totalFee": 2.00,
   "amount": 0.000383,
-  "paymentPresentationRequest": { }
+  "paymentPresentationRequestJwt": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa3NpcEpqd1RZb2Y2YXRiQnJreDVienJTTVhyUVVkZkJlOGFqcmhaY3JieFhuI3o2TWtzaXBKandUWW9mNmF0YkJya3g1YnpyU01YclFVZGZCZThhanJoWmNyYnhYbiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2ODYwODE3NTYsImlhdCI6MTY4NjA4MTc1NiwiaXNzIjoiZGlkOmtleTp6Nk1rc2lwSmp3VFlvZjZhdGJCcmt4NWJ6clNNWHJRVWRmQmU4YWpyaFpjcmJ4WG4iLCJqdGkiOiIyNTQ2YjZkNi0yYzlkLTRjNzEtYjlhNi02ZDI3OWJiNzdlYjciLCJuYmYiOjE2ODYwODE3NTYsInByZXNlbnRhdGlvbl9kZWZpbml0aW9uIjp7ImlkIjoiNmVmNzk2MzgtNTRjMS00MjU0LTkzNWUtMjFhNzliYTMzZTU2IiwiaW5wdXRfZGVzY3JpcHRvcnMiOlt7ImNvbnN0cmFpbnRzIjp7ImZpZWxkcyI6W3sibmFtZSI6IkRlYml0IGNhcmQgbnVtYmVyIiwicGF0aCI6WyIkLmRlYml0Q2FyZE51bWJlciIsIiQudmMuZGViaXRDYXJkTnVtYmVyIl19LHsibmFtZSI6IkRlYml0IGNhcmQgZXhwaXJ5IiwicGF0aCI6WyIkLmRlYml0Q2FyZEV4cGlyeURhdGUiLCIkLnZjLmRlYml0Q2FyZEV4cGlyeURhdGUiXX0seyJuYW1lIjoiRGViaXQgY2FyZCBDVlYiLCJwYXRoIjpbIiQuZGViaXRDYXJkQ1ZWIiwiJC52Yy5kZWJpdENhcmRDVlYiLCIkLnZjLmN2diJdfV19LCJpZCI6IjAiLCJwdXJwb3NlIjoiUHJvdmlkZSBkZWJpdCBjYXJkIGluZm8gc28gUEZJIGNhbiBjaGFyZ2UgVVNEIn0seyJjb25zdHJhaW50cyI6eyJmaWVsZHMiOlt7Im5hbWUiOiJCVEMgQWRkcmVzcyIsInBhdGgiOlsiJC5idGNBZGRyZXNzIiwiJC52Yy5idGNBZGRyZXNzIiwiJC5iaXRjb2luQWRkcmVzcyIsIiQudmMuYml0Y29pbkFkZHJlc3MiXX1dfSwiaWQiOiIxIiwicHVycG9zZSI6IlByb3ZpZGUgYnRjIGFkZHJlc3MgaW5mbyBzbyBQRkkgY2FuIHNlbmQgQlRDIn1dLCJuYW1lIjoiUGF5aW4vUGF5b3V0IGluc3RydW1lbnQgcHJlc2VudGF0aW9uIGRlZmluaXRpb24iLCJwdXJwb3NlIjoiUHJvdmlkZSBwYXltZW50IGluc3RydW1lbnRzIHNvIHdlIGNhbiBkbyBhIGJ1c2luZXNzIHRoaW5nIn19.dRS5UTPDJmLsaO4YVhKH1brA_wUQohU-6BxxvNMMcdQq5BfXYQ64VaRer7tlA7t26AYephpx2zSaQIgEWfNnAw"
 }
 
 let order = {

--- a/protocol/tbdex_schema_examples.js
+++ b/protocol/tbdex_schema_examples.js
@@ -1,0 +1,50 @@
+let offering = {
+  "pair": "BTC_USD",
+  "unitPrice": 27000.00,
+  "fee": 1.00,
+  "min": 10.00,
+  "max": 100.00,
+  "presentationRequest": { },
+  "payinInstruments": [{
+      "kind": "DEBIT_CARD",
+      "fee": 1,
+      "presentationRequest": {},
+  }],
+  "payoutInstruments": [{
+      "kind": "BTC_ADDRESS",
+      "presentationRequest": {}
+  }]
+}
+
+let rfq = {
+  "rfqId": "1",
+  "pair": "BTC_USD",
+  "amount": 10.00,
+  "verifiablePresentation": { },
+  "payin_instrument": {
+      "kind": "DEBIT_CARD"
+  },
+  "payout_instrument": {
+      "kind": "BTC_ADDRESS"
+  }
+}
+
+let quote = {
+  "rfqId": "1",
+  "quoteId": "2",
+  "expiryTime": "2023-04-14T12:12:12Z",
+  "totalFee": 1.00,
+  "amount": 0.000383,
+  "paymentPresentationRequest": { }
+}
+
+let order = {
+    "orderId": 32432,
+    "quoteId": 2,
+    "paymentVerifiablePresentation": { }
+}
+
+let orderStatus = {
+    "orderId": 32432,
+    "orderStatus": "PENDING"
+}

--- a/protocol/tbdex_schema_examples.js
+++ b/protocol/tbdex_schema_examples.js
@@ -1,51 +1,50 @@
 let offering = {
-  "description": "Buy BTC with USD, much wow!",
+  "description": "Buy BTC with USD!",
   "pair": "BTC_USD",
   "unitPrice": 27000.00,
   "baseFee": 1.00,
   "min": 10.00,
-  "max": 100.00,
-  "presentationRequestJwt": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa3NpcEpqd1RZb2Y2YXRiQnJreDVienJTTVhyUVVkZkJlOGFqcmhaY3JieFhuI3o2TWtzaXBKandUWW9mNmF0YkJya3g1YnpyU01YclFVZGZCZThhanJoWmNyYnhYbiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2ODYwOTE2NTksImlhdCI6MTY4NjA5MTY1OSwiaXNzIjoiZGlkOmtleTp6Nk1rc2lwSmp3VFlvZjZhdGJCcmt4NWJ6clNNWHJRVWRmQmU4YWpyaFpjcmJ4WG4iLCJqdGkiOiJhNWFkYzM2OC1lYWM3LTQ0ZTMtYjlhMi04ZDE3MTY1MmFjYzUiLCJuYmYiOjE2ODYwOTE2NTksInByZXNlbnRhdGlvbl9kZWZpbml0aW9uIjp7ImlkIjoiM2E2NjM0OTgtMjNjYy00NWQ3LThjNzYtZTJhZWUxMzdmYTdkIiwiaW5wdXRfZGVzY3JpcHRvcnMiOlt7ImNvbnN0cmFpbnRzIjp7ImZpZWxkcyI6W3sibmFtZSI6IkZ1bGwgTmFtZSIsInBhdGgiOlsiJC5mdWxsTmFtZSIsIiQudmMuZnVsbE5hbWUiXX0seyJuYW1lIjoiRGF0ZSBvZiBCaXJ0aCIsInBhdGgiOlsiJC5kYXRlT2ZCaXJ0aCIsIiQudmMuZGF0ZU9mQmlydGgiLCIkLmRvYiIsIiQudmMuZG9iIl19XX0sImlkIjoiMCIsInB1cnBvc2UiOiJLWUMgVkMifV0sIm5hbWUiOiJLWUMgVkMgUHJlc2VudGF0aW9uIERlZmluaXRpb24iLCJwdXJwb3NlIjoiUHJvdmlkZSBpbmZvIHNvIHdlIGtub3cgeW91IGFyZSBub3QgYSBiYWRkaWUifX0.bL8br3_5jkHZF6XAFtoVa4opBw_zfBtYYEynxA9jD8uvZ1tJC47uQ8aG_Ds6odFaZNgY3tf0uWFcrK9S-0MIDw",
+  "max": 1000.00,
+  "presentationRequestJwt": "eyJhb...MIDw",
   "payinInstruments": [{
-      "kind": "DEBIT_CARD",
-      "fee": {
-        "flatFee": 1.00
-      }
+    "kind": "DEBIT_CARD",
+    "fee": {
+      "flatFee": 1.00
+    }
   }],
   "payoutInstruments": [{
-      "kind": "BTC_ADDRESS"
+    "kind": "BTC_ADDRESS"
   }]
 }
 
 let rfq = {
-  "rfqId": "1",
   "pair": "BTC_USD",
   "amount": 10.00,
-  "verifiablePresentation": { },
+  "verifiablePresentationJwt": "...",
   "payinInstrument": {
-      "kind": "DEBIT_CARD"
+    "kind": "DEBIT_CARD"
   },
-  "payoutInnstrument": {
-      "kind": "BTC_ADDRESS"
+  "payoutInstrument": {
+    "kind": "BTC_ADDRESS"
   }
 }
 
 let quote = {
-  "rfqId": "1",
-  "quoteId": "2",
   "expiryTime": "2023-04-14T12:12:12Z",
   "totalFee": 2.00,
   "amount": 0.000383,
-  "paymentPresentationRequestJwt": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa3NpcEpqd1RZb2Y2YXRiQnJreDVienJTTVhyUVVkZkJlOGFqcmhaY3JieFhuI3o2TWtzaXBKandUWW9mNmF0YkJya3g1YnpyU01YclFVZGZCZThhanJoWmNyYnhYbiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2ODYwODE3NTYsImlhdCI6MTY4NjA4MTc1NiwiaXNzIjoiZGlkOmtleTp6Nk1rc2lwSmp3VFlvZjZhdGJCcmt4NWJ6clNNWHJRVWRmQmU4YWpyaFpjcmJ4WG4iLCJqdGkiOiIyNTQ2YjZkNi0yYzlkLTRjNzEtYjlhNi02ZDI3OWJiNzdlYjciLCJuYmYiOjE2ODYwODE3NTYsInByZXNlbnRhdGlvbl9kZWZpbml0aW9uIjp7ImlkIjoiNmVmNzk2MzgtNTRjMS00MjU0LTkzNWUtMjFhNzliYTMzZTU2IiwiaW5wdXRfZGVzY3JpcHRvcnMiOlt7ImNvbnN0cmFpbnRzIjp7ImZpZWxkcyI6W3sibmFtZSI6IkRlYml0IGNhcmQgbnVtYmVyIiwicGF0aCI6WyIkLmRlYml0Q2FyZE51bWJlciIsIiQudmMuZGViaXRDYXJkTnVtYmVyIl19LHsibmFtZSI6IkRlYml0IGNhcmQgZXhwaXJ5IiwicGF0aCI6WyIkLmRlYml0Q2FyZEV4cGlyeURhdGUiLCIkLnZjLmRlYml0Q2FyZEV4cGlyeURhdGUiXX0seyJuYW1lIjoiRGViaXQgY2FyZCBDVlYiLCJwYXRoIjpbIiQuZGViaXRDYXJkQ1ZWIiwiJC52Yy5kZWJpdENhcmRDVlYiLCIkLnZjLmN2diJdfV19LCJpZCI6IjAiLCJwdXJwb3NlIjoiUHJvdmlkZSBkZWJpdCBjYXJkIGluZm8gc28gUEZJIGNhbiBjaGFyZ2UgVVNEIn0seyJjb25zdHJhaW50cyI6eyJmaWVsZHMiOlt7Im5hbWUiOiJCVEMgQWRkcmVzcyIsInBhdGgiOlsiJC5idGNBZGRyZXNzIiwiJC52Yy5idGNBZGRyZXNzIiwiJC5iaXRjb2luQWRkcmVzcyIsIiQudmMuYml0Y29pbkFkZHJlc3MiXX1dfSwiaWQiOiIxIiwicHVycG9zZSI6IlByb3ZpZGUgYnRjIGFkZHJlc3MgaW5mbyBzbyBQRkkgY2FuIHNlbmQgQlRDIn1dLCJuYW1lIjoiUGF5aW4vUGF5b3V0IGluc3RydW1lbnQgcHJlc2VudGF0aW9uIGRlZmluaXRpb24iLCJwdXJwb3NlIjoiUHJvdmlkZSBwYXltZW50IGluc3RydW1lbnRzIHNvIHdlIGNhbiBkbyBhIGJ1c2luZXNzIHRoaW5nIn19.dRS5UTPDJmLsaO4YVhKH1brA_wUQohU-6BxxvNMMcdQq5BfXYQ64VaRer7tlA7t26AYephpx2zSaQIgEWfNnAw"
+  "paymentPresentationRequestJwt": "eyJhbGc...EWfNnAw",
+  "paymentInstructions": {
+    "payin": {
+      "link": "stripe.com?for=alice"
+    }
+  }
 }
 
 let order = {
-    "orderId": 32432,
-    "quoteId": 2,
-    "paymentVerifiablePresentation": { }
+  "paymentVerifiablePresentationJwt": "..."
 }
 
 let orderStatus = {
-    "orderId": 32432,
-    "orderStatus": "PENDING"
+  "orderStatus": "PENDING"
 }

--- a/protocol/tbdex_schema_examples.js
+++ b/protocol/tbdex_schema_examples.js
@@ -1,18 +1,18 @@
 let offering = {
   "pair": "BTC_USD",
   "unitPrice": 27000.00,
-  "fee": 1.00,
+  "baseFee": 1.00,
   "min": 10.00,
   "max": 100.00,
   "presentationRequest": { },
   "payinInstruments": [{
       "kind": "DEBIT_CARD",
-      "fee": 1,
-      "presentationRequest": {},
+      "fee": {
+        "flatFee": 1.00
+      }
   }],
   "payoutInstruments": [{
-      "kind": "BTC_ADDRESS",
-      "presentationRequest": {}
+      "kind": "BTC_ADDRESS"
   }]
 }
 
@@ -33,7 +33,7 @@ let quote = {
   "rfqId": "1",
   "quoteId": "2",
   "expiryTime": "2023-04-14T12:12:12Z",
-  "totalFee": 1.00,
+  "totalFee": 2.00,
   "amount": 0.000383,
   "paymentPresentationRequest": { }
 }


### PR DESCRIPTION
Updating the readme to include offering as a message type (see [this other issue](https://github.com/TBD54566975/tbdex-protocol/issues/75)), as well as update other message types that change as a result of offering being introduced. 