### PR TITLE
Compile validators

### DIFF
--- a/protocol/implementations/js/.eslintrc.cjs
+++ b/protocol/implementations/js/.eslintrc.cjs
@@ -13,7 +13,8 @@ module.exports = {
   },
   ignorePatterns: [
     'dist',
-    'tests/compiled'
+    'tests/compiled',
+    'generated'
   ],
   rules: {
     'key-spacing': [

--- a/protocol/implementations/js/.gitignore
+++ b/protocol/implementations/js/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 tests/compiled
+generated

--- a/protocol/implementations/js/build/compile-validators.js
+++ b/protocol/implementations/js/build/compile-validators.js
@@ -2,7 +2,7 @@
  * Pre-compiles Ajv validators from json schemas
  * Ajv supports generating standalone validation functions from JSON Schemas at compile/build time.
  * These functions can then be used during runtime to do validation without initializing Ajv.
- * It is useful for several reasons:
+ * This is useful for several reasons:
  * - to avoid dynamic code evaluation with Function constructor (used for schema compilation) -
  *   when it is prohibited by the browser page [Content Security Policy](https://ajv.js.org/security.html#content-security-policy).
  * - to reduce the browser bundle size - Ajv is not included in the bundle
@@ -11,7 +11,11 @@
 
 import definitions from '../../json-schemas/definitions.json' assert { type: 'json' }
 import tbdexMessage from '../../json-schemas/message.schema.json' assert { type: 'json' }
+import offering from '../../json-schemas/offering.schema.json' assert { type: 'json' }
 import rfq from '../../json-schemas/rfq.schema.json' assert { type: 'json' }
+import quote from '../../json-schemas/quote.schema.json' assert { type: 'json' }
+import order from '../../json-schemas/order.schema.json' assert { type: 'json' }
+import orderStatus from '../../json-schemas/order-status.schema.json' assert { type: 'json' }
 
 import fs from 'node:fs'
 import path from 'node:path'
@@ -24,7 +28,11 @@ import standaloneCode from 'ajv/dist/standalone/index.js'
 const schemas = {
   definitions,
   tbdexMessage,
-  rfq
+  offering,
+  rfq,
+  quote,
+  order,
+  orderStatus
 }
 
 const validator = new Ajv({ code: { source: true, esm: true } })
@@ -37,4 +45,4 @@ const moduleCode = standaloneCode(validator)
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 
 await mkdirp(path.join(__dirname, '../generated'))
-fs.writeFileSync(path.join(__dirname, '../generated/precompiled-validators.js'), moduleCode)
+fs.writeFileSync(path.join(__dirname, '../generated/compiled-validators.js'), moduleCode)

--- a/protocol/implementations/js/build/esbuild-browser-config.cjs
+++ b/protocol/implementations/js/build/esbuild-browser-config.cjs
@@ -1,7 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const polyfillProviderPlugin = require('node-stdlib-browser/helpers/esbuild/plugin')
-const stdLibBrowser = require('node-stdlib-browser')
-
 /** @type {import('esbuild').BuildOptions} */
 module.exports = {
   entryPoints : ['./src/main.ts'],
@@ -11,8 +7,6 @@ module.exports = {
   minify      : true,
   platform    : 'browser',
   target      : ['chrome101', 'firefox108', 'safari16'],
-  inject      : [require.resolve('node-stdlib-browser/helpers/esbuild/shim')],
-  plugins     : [polyfillProviderPlugin(stdLibBrowser)],
   define      : {
     'global': 'globalThis',
   },

--- a/protocol/implementations/js/build/esbuild-browser-config.cjs
+++ b/protocol/implementations/js/build/esbuild-browser-config.cjs
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const polyfillProviderPlugin = require('node-stdlib-browser/helpers/esbuild/plugin');
-const stdLibBrowser = require('node-stdlib-browser');
+const polyfillProviderPlugin = require('node-stdlib-browser/helpers/esbuild/plugin')
+const stdLibBrowser = require('node-stdlib-browser')
 
 /** @type {import('esbuild').BuildOptions} */
 module.exports = {
@@ -16,4 +16,4 @@ module.exports = {
   define      : {
     'global': 'globalThis',
   },
-};
+}

--- a/protocol/implementations/js/build/precompile-validators.js
+++ b/protocol/implementations/js/build/precompile-validators.js
@@ -1,0 +1,40 @@
+/**
+ * Pre-compiles Ajv validators from json schemas
+ * Ajv supports generating standalone validation functions from JSON Schemas at compile/build time.
+ * These functions can then be used during runtime to do validation without initializing Ajv.
+ * It is useful for several reasons:
+ * - to avoid dynamic code evaluation with Function constructor (used for schema compilation) -
+ *   when it is prohibited by the browser page [Content Security Policy](https://ajv.js.org/security.html#content-security-policy).
+ * - to reduce the browser bundle size - Ajv is not included in the bundle
+ * - to reduce the start-up time - the validation and compilation of schemas will happen during build time.
+ */
+
+import definitions from '../../json-schemas/definitions.json' assert { type: 'json' }
+import tbdexMessage from '../../json-schemas/message.schema.json' assert { type: 'json' }
+import rfq from '../../json-schemas/rfq.schema.json' assert { type: 'json' }
+
+import fs from 'node:fs'
+import path from 'node:path'
+import url from 'node:url'
+
+import Ajv from 'ajv'
+import { mkdirp } from 'mkdirp'
+import standaloneCode from 'ajv/dist/standalone/index.js'
+
+const schemas = {
+  definitions,
+  tbdexMessage,
+  rfq
+}
+
+const validator = new Ajv({ code: { source: true, esm: true } })
+
+for (const schemaName in schemas) {
+  validator.addSchema(schemas[schemaName], schemaName)
+}
+
+const moduleCode = standaloneCode(validator)
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
+
+await mkdirp(path.join(__dirname, '../generated'))
+fs.writeFileSync(path.join(__dirname, '../generated/precompiled-validators.js'), moduleCode)

--- a/protocol/implementations/js/package-lock.json
+++ b/protocol/implementations/js/package-lock.json
@@ -30,6 +30,7 @@
         "karma-mocha": "2.0.1",
         "karma-mocha-reporter": "2.2.5",
         "karma-webkit-launcher": "2.1.0",
+        "mkdirp": "3.0.1",
         "mocha": "10.2.0",
         "node-stdlib-browser": "1.2.0",
         "rimraf": "4.4.0",
@@ -3477,6 +3478,18 @@
         "node": "*"
       }
     },
+    "node_modules/karma/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/karma/node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -3800,15 +3813,18 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
       "bin": {
-        "mkdirp": "bin/cmd.js"
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mocha": {

--- a/protocol/implementations/js/package-lock.json
+++ b/protocol/implementations/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/tbdex",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/tbdex",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "8.12.0",
@@ -37,6 +37,15 @@
         "rimraf": "4.4.0",
         "sinon": "15.0.2",
         "typescript": "5.0.4"
+      }
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-plhoNEfSVdHMKXQyAxvH0Zyv3/4NL8r6pwgMQdmHR2vBUXn2t74PN2pBRppqKUa6RMT0yldyvOHG5Dbjwy2mBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -463,33 +472,11 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
-    },
-    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/@eslint/js": {
       "version": "8.43.0",
@@ -512,28 +499,6 @@
       },
       "engines": {
         "node": ">=10.10.0"
-      }
-    },
-    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -619,9 +584,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.1.0.tgz",
-      "integrity": "sha512-w1qd368vtrwttm1PRJWPW1QHlbmHrVDGs1eBH/jZvRPUFS4MNXV9Q33EQdjOdeAxZ7O8+3wM7zxztm2nfUSyKw==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
@@ -709,9 +674,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
-      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
+      "version": "20.3.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.2.tgz",
+      "integrity": "sha512-vOBLVQeCQfIcF/2Y7eKFTqrMnizK5lRNQ7ykML/5RuwVXVWxYkgwS7xbt4B6fKCUPgbSL5FSsjHQpaGQP/dQmw==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -1174,28 +1139,14 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "dev": true,
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
@@ -1797,9 +1748,9 @@
       "dev": true
     },
     "node_modules/diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
@@ -1913,9 +1864,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.2.tgz",
-      "integrity": "sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.1.tgz",
+      "integrity": "sha512-mGqhI+D7YxS9KJMppR6Iuo37Ed3abhU8NdfgSvJSDUafQutrN+sPTncJYTyM9+tkhSmWodKtVYGPPHyXJEwEQA==",
       "dev": true,
       "dependencies": {
         "@types/cookie": "^0.4.1",
@@ -1926,7 +1877,7 @@
         "cookie": "~0.4.1",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.3",
+        "engine.io-parser": "~5.1.0",
         "ws": "~8.11.0"
       },
       "engines": {
@@ -1934,9 +1885,9 @@
       }
     },
     "node_modules/engine.io-parser": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.7.tgz",
-      "integrity": "sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.1.0.tgz",
+      "integrity": "sha512-enySgNiK5tyZFynt3z7iqBR+Bto9EVVVvDFuTT0ioHCGbzirZVGDGiQjZzEp8hWl6hd5FSVytJGuScX1C1C35w==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -2115,16 +2066,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
@@ -2155,18 +2096,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/espree": {
       "version": "9.5.2",
@@ -2437,48 +2366,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/flat-cache/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/flat-cache/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/flat-cache/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/flat-cache/node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -2603,18 +2490,20 @@
       }
     },
     "node_modules/glob": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
-        "minimatch": "^8.0.2",
-        "minipass": "^4.2.4",
-        "path-scurry": "^1.6.1"
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "*"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3443,48 +3332,6 @@
         }
       }
     },
-    "node_modules/karma/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/karma/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/karma/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/karma/node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -3672,12 +3519,15 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
-      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
       "engines": {
-        "node": "14 || >=16.14"
+        "node": ">=10"
       }
     },
     "node_modules/md5.js": {
@@ -3787,18 +3637,15 @@
       "dev": true
     },
     "node_modules/minimatch": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "*"
       }
     },
     "node_modules/minimist": {
@@ -3874,15 +3721,6 @@
         "url": "https://opencollective.com/mochajs"
       }
     },
-    "node_modules/mocha/node_modules/diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/mocha/node_modules/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -3901,16 +3739,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
@@ -3951,6 +3779,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/mocha/node_modules/ms": {
@@ -4147,17 +3984,17 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
       "dev": true,
       "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -4279,12 +4116,12 @@
       "dev": true
     },
     "node_modules/path-scurry": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
-      "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.0.tgz",
+      "integrity": "sha512-tZFEaRQbMLjwrsmidsGJ6wDMv0iazJWk6SfIKnY4Xru8auXgmJkOBa5DUbYFcFD2Rzk2+KDlIiF0GVXNCbgC7g==",
       "dev": true,
       "dependencies": {
-        "lru-cache": "^9.1.1",
+        "lru-cache": "^9.1.1 || ^10.0.0",
         "minipass": "^5.0.0 || ^6.0.2"
       },
       "engines": {
@@ -4292,6 +4129,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+      "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
       }
     },
     "node_modules/path-scurry/node_modules/minipass": {
@@ -4436,9 +4282,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
-      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dev": true,
       "dependencies": {
         "side-channel": "^1.0.4"
@@ -4631,6 +4477,48 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ripemd160": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
@@ -4691,27 +4579,15 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -4804,6 +4680,15 @@
         "url": "https://opencollective.com/sinon"
       }
     },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4814,15 +4699,16 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.2.tgz",
-      "integrity": "sha512-Vp+lSks5k0dewYTfwgPT9UeGGd+ht7sCpB7p0e83VgO4X/AHYWhXITMrNk/pg8syY2bpx23ptClCQuHhqi2BgQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.0.tgz",
+      "integrity": "sha512-eOpu7oCNiPGBHn9Falg0cAGivp6TpDI3Yt596fbsf+vln8kRLFWxXKrecFrybn/xNYVn9HcdJNAkYToCmTjsyg==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
+        "cors": "~2.8.5",
         "debug": "~4.3.2",
-        "engine.io": "~6.4.2",
+        "engine.io": "~6.5.0",
         "socket.io-adapter": "~2.5.2",
         "socket.io-parser": "~4.2.4"
       },
@@ -5005,48 +4891,6 @@
       },
       "engines": {
         "node": ">=8.17.0"
-      }
-    },
-    "node_modules/tmp/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/tmp/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/tmp/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/tmp/node_modules/rimraf": {
@@ -5339,15 +5183,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/workerpool": {

--- a/protocol/implementations/js/package-lock.json
+++ b/protocol/implementations/js/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@playwright/test": "1.34.3",
+        "@types/chai": "4.3.5",
         "@types/eslint": "8.37.0",
         "@types/mocha": "10.0.1",
         "@typescript-eslint/eslint-plugin": "5.59.0",
@@ -656,6 +657,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
+      "dev": true
+    },
+    "node_modules/@types/chai": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
       "dev": true
     },
     "node_modules/@types/cookie": {

--- a/protocol/implementations/js/package.json
+++ b/protocol/implementations/js/package.json
@@ -79,9 +79,9 @@
     "compile-validators": "rimraf generated && node build/compile-validators.js",
     "build:esm": "rimraf dist/esm dist/types && npx tsc -p tsconfig.json",
     "build:cjs": "rimraf dist/cjs && npx tsc -p tsconfig.cjs.json && echo '{\"type\": \"commonjs\"}' > ./dist/cjs/package.json",
-    "build:browser": "rimraf dist/browser.mjs dist/browser.js && npm run compile-validators && node build/bundles.js",
+    "build:browser": "rimraf dist/browser.mjs dist/browser.js && node build/bundles.js",
     "test:node": "rimraf tests/compiled && npm run compile-validators && tsc -p tests/tsconfig.json && mocha",
-    "test:browser": "karma start karma.conf.cjs",
+    "test:browser": "npm run compile-validators && karma start karma.conf.cjs",
     "build": "npm run clean && npm run compile-validators && npm run build:esm && npm run build:cjs && npm run build:browser",
     "lint": "eslint . --ext .ts --max-warnings 0",
     "lint:fix": "eslint . --ext .ts --fix"

--- a/protocol/implementations/js/package.json
+++ b/protocol/implementations/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/tbdex",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "description": "Library that includes type definitions for tbdex messages",
   "license": "Apache-2.0",
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.34.3",
+    "@types/chai": "4.3.5",
     "@types/eslint": "8.37.0",
     "@types/mocha": "10.0.1",
     "@typescript-eslint/eslint-plugin": "5.59.0",
@@ -74,13 +75,14 @@
     "typescript": "5.0.4"
   },
   "scripts": {
-    "clean": "rimraf dist tests/compiled",
+    "clean": "rimraf generated dist tests/compiled",
+    "compile-validators": "rimraf generated && node build/compile-validators.js",
     "build:esm": "rimraf dist/esm dist/types && npx tsc -p tsconfig.json",
     "build:cjs": "rimraf dist/cjs && npx tsc -p tsconfig.cjs.json && echo '{\"type\": \"commonjs\"}' > ./dist/cjs/package.json",
     "build:browser": "rimraf dist/browser.mjs dist/browser.js && node build/bundles.js",
-    "test:node": "rimraf tests/compiled && tsc -p tests/tsconfig.json && mocha",
+    "test:node": "rimraf tests/compiled && npm run compile-validators && tsc -p tests/tsconfig.json && mocha",
     "test:browser": "karma start karma.conf.cjs",
-    "build": "npm run clean && npm run build:esm && npm run build:cjs && npm run build:browser",
+    "build": "npm run clean && npm run compile-validators && npm run build:esm && npm run build:cjs && npm run build:browser",
     "lint": "eslint . --ext .ts --max-warnings 0",
     "lint:fix": "eslint . --ext .ts --fix"
   }

--- a/protocol/implementations/js/package.json
+++ b/protocol/implementations/js/package.json
@@ -79,7 +79,7 @@
     "compile-validators": "rimraf generated && node build/compile-validators.js",
     "build:esm": "rimraf dist/esm dist/types && npx tsc -p tsconfig.json",
     "build:cjs": "rimraf dist/cjs && npx tsc -p tsconfig.cjs.json && echo '{\"type\": \"commonjs\"}' > ./dist/cjs/package.json",
-    "build:browser": "rimraf dist/browser.mjs dist/browser.js && node build/bundles.js",
+    "build:browser": "rimraf dist/browser.mjs dist/browser.js && npm run compile-validators && node build/bundles.js",
     "test:node": "rimraf tests/compiled && npm run compile-validators && tsc -p tests/tsconfig.json && mocha",
     "test:browser": "karma start karma.conf.cjs",
     "build": "npm run clean && npm run compile-validators && npm run build:esm && npm run build:cjs && npm run build:browser",

--- a/protocol/implementations/js/package.json
+++ b/protocol/implementations/js/package.json
@@ -66,6 +66,7 @@
     "karma-mocha": "2.0.1",
     "karma-mocha-reporter": "2.2.5",
     "karma-webkit-launcher": "2.1.0",
+    "mkdirp": "3.0.1",
     "mocha": "10.2.0",
     "node-stdlib-browser": "1.2.0",
     "rimraf": "4.4.0",

--- a/protocol/implementations/js/src/main.ts
+++ b/protocol/implementations/js/src/main.ts
@@ -1,3 +1,4 @@
 export * from './types.js'
 export * from './builders.js'
 export * from './validator.js'
+export * from './protocolDefinitions.js'

--- a/protocol/implementations/js/src/protocolDefinitions.ts
+++ b/protocol/implementations/js/src/protocolDefinitions.ts
@@ -1,121 +1,121 @@
 export const aliceProtocolDefinition = {
-    protocol: 'https://tbd.website/protocols/tbdex',
-    types: {
-        RFQ: {
-            schema: 'https://tbd.website/protocols/tbdex/RequestForQuote',
-            dataFormats: [
-                'application/json'
-            ]
-        },
-        Quote: {
-            schema: 'https://tbd.website/protocols/tbdex/Quote',
-            dataFormats: [
-                'application/json'
-            ]
-        },
-        Order: {
-            schema: 'https://tbd.website/protocols/tbdex/Order',
-            dataFormats: [
-                'application/json'
-            ]
-        },
-        OrderStatus: {
-            schema: 'https://tbd.website/protocols/tbdex/OrderStatus',
-            dataFormats: [
-                'application/json'
-            ]
-        }
+  protocol : 'https://tbd.website/protocols/tbdex',
+  types    : {
+    RFQ: {
+      schema      : 'https://tbd.website/protocols/tbdex/RequestForQuote',
+      dataFormats : [
+        'application/json'
+      ]
     },
-    structure: {
-        // alice sends RFQs, not receives them
-        RFQ: {
-            $actions: [],
-            // whoever received the RFQ that Alice sent, can write back a Quote to Alice
-            Quote: {
-                $actions: [
-                    {
-                        who: 'recipient',
-                        of: 'RFQ',
-                        can: 'write'
-                    }
-                ],
-                // alice sends Orders, not receives them
-                Order: {
-                    $actions: [],
-                    // whoever received the order that Alice sent in response to a Quote in response to an RFQ, can write back an OrderStatus to Alice.
-                    OrderStatus: {
-                        $actions: [
-                            {
-                                who: 'recipient',
-                                of: 'RFQ/Quote/Order',
-                                can: 'write'
-                            }
-                        ]
-                    }
-                }
-            }
-        }
+    Quote: {
+      schema      : 'https://tbd.website/protocols/tbdex/Quote',
+      dataFormats : [
+        'application/json'
+      ]
+    },
+    Order: {
+      schema      : 'https://tbd.website/protocols/tbdex/Order',
+      dataFormats : [
+        'application/json'
+      ]
+    },
+    OrderStatus: {
+      schema      : 'https://tbd.website/protocols/tbdex/OrderStatus',
+      dataFormats : [
+        'application/json'
+      ]
     }
-};
+  },
+  structure: {
+    // alice sends RFQs, not receives them
+    RFQ: {
+      $actions : [],
+      // whoever received the RFQ that Alice sent, can write back a Quote to Alice
+      Quote    : {
+        $actions: [
+          {
+            who : 'recipient',
+            of  : 'RFQ',
+            can : 'write'
+          }
+        ],
+        // alice sends Orders, not receives them
+        Order: {
+          $actions    : [],
+          // whoever received the order that Alice sent in response to a Quote in response to an RFQ, can write back an OrderStatus to Alice.
+          OrderStatus : {
+            $actions: [
+              {
+                who : 'recipient',
+                of  : 'RFQ/Quote/Order',
+                can : 'write'
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
 
 
 export const pfiProtocolDefinition = {
-    protocol: 'https://tbd.website/protocols/tbdex',
-    types: {
-        RFQ: {
-            schema: 'https://tbd.website/protocols/tbdex/RequestForQuote',
-            dataFormats: [
-                'application/json'
-            ]
-        },
-        Quote: {
-            schema: 'https://tbd.website/protocols/tbdex/Quote',
-            dataFormats: [
-                'application/json'
-            ]
-        },
-        Order: {
-            schema: 'https://tbd.website/protocols/tbdex/Order',
-            dataFormats: [
-                'application/json'
-            ]
-        },
-        OrderStatus: {
-            schema: 'https://tbd.website/protocols/tbdex/OrderStatus',
-            dataFormats: [
-                'application/json'
-            ]
-        }
+  protocol : 'https://tbd.website/protocols/tbdex',
+  types    : {
+    RFQ: {
+      schema      : 'https://tbd.website/protocols/tbdex/RequestForQuote',
+      dataFormats : [
+        'application/json'
+      ]
     },
-    structure: {
-        // anyone can write RFQ to a PFIs DWN
-        // no one can read RFQs from PFIs DWN (except the PFI itself)
-        RFQ: {
-            $actions: [
-                {
-                    who: 'anyone',
-                    can: 'write'
-                }
-            ],
-            // PFI is sending OUT quotes. no one should be writing Quotes to PFIs.
-            Quote: {
-                $actions: [],
-                // only Alice, who received an RFQ/Quote, can write Order to PFIs DWN
-                // no one can read Order from PFIs DWN (except the PFI itself)
-                Order: {
-                    $actions: [
-                        {
-                            who: 'recipient',
-                            of: 'RFQ/Quote',
-                            can: 'write'
-                        }
-                    ],
-                    // PFI is sending OUT OrderStatus. no one should be writing OrderStatus to PFIs.
-                    OrderStatus: {
-                        $actions: []
-                    }
-                }
-            }
-        }
+    Quote: {
+      schema      : 'https://tbd.website/protocols/tbdex/Quote',
+      dataFormats : [
+        'application/json'
+      ]
+    },
+    Order: {
+      schema      : 'https://tbd.website/protocols/tbdex/Order',
+      dataFormats : [
+        'application/json'
+      ]
+    },
+    OrderStatus: {
+      schema      : 'https://tbd.website/protocols/tbdex/OrderStatus',
+      dataFormats : [
+        'application/json'
+      ]
     }
-};
+  },
+  structure: {
+    // anyone can write RFQ to a PFIs DWN
+    // no one can read RFQs from PFIs DWN (except the PFI itself)
+    RFQ: {
+      $actions: [
+        {
+          who : 'anyone',
+          can : 'write'
+        }
+      ],
+      // PFI is sending OUT quotes. no one should be writing Quotes to PFIs.
+      Quote: {
+        $actions : [],
+        // only Alice, who received an RFQ/Quote, can write Order to PFIs DWN
+        // no one can read Order from PFIs DWN (except the PFI itself)
+        Order    : {
+          $actions: [
+            {
+              who : 'recipient',
+              of  : 'RFQ/Quote',
+              can : 'write'
+            }
+          ],
+          // PFI is sending OUT OrderStatus. no one should be writing OrderStatus to PFIs.
+          OrderStatus: {
+            $actions: []
+          }
+        }
+      }
+    }
+  }
+}

--- a/protocol/implementations/js/src/validator.ts
+++ b/protocol/implementations/js/src/validator.ts
@@ -1,33 +1,42 @@
-import * as precompiledValidators from '../generated/precompiled-validators.js'
+import type { ErrorObject } from 'ajv'
+// validator functions are compiled at build time. check ./build/compile-validators.js for more details
+import * as compiledValidators from '../generated/compiled-validators.js'
 
+/**
+ * 2-phased validation. validates the outer message first and then validates the body based on the value of payload.type
+ * @param payload - the payload to validate
+ */
 export function validateMessage(payload: any): void {
-  let validateFn = (precompiledValidators as any)['tbdexMessage']
+  let validateFn = (compiledValidators as any)['tbdexMessage']
   validateFn(payload)
 
   if (validateFn.errors) {
-    // TODO modify default, return all errors
-    // AJV is configured by default to stop validating after the 1st error is encountered which means
-    // there will only ever be one error;
-    const [errorObj] = validateFn.errors
-    let { instancePath, message } = errorObj
-
-    throw new SchemaValidationError(`${instancePath ?? 'tbDEXMessage'}: ${message}`)
+    handleValidationError(validateFn.errors)
   }
 
-  validateFn = (precompiledValidators as any)[payload['type']]
+  // select the appropriate validator based on the value of `payload.type`
+  validateFn = (compiledValidators as any)[payload['type']]
   validateFn(payload['body'])
 
   if (validateFn.errors) {
-    // TODO modify default, return all errors
-    // AJV is configured by default to stop validating after the 1st error is encountered which means
-    // there will only ever be one error;
-    const [errorObj] = validateFn.errors
-    const { instancePath, message } = errorObj
-
-    throw new SchemaValidationError(`${instancePath ?? 'tbDEXMessage'}: ${message}`)
+    handleValidationError(validateFn.errors)
   }
+}
 
+function handleValidationError(errors: ErrorObject[]) {
+  // TODO modify default, return all errors
+  // AJV is configured by default to stop validating after the 1st error is encountered which means
+  // there will only ever be one error;
+  const [ errorObj ]: ErrorObject[] = errors
+  let { instancePath, message, params } = errorObj
 
+  instancePath ||= 'tbDEXMessage'
+
+  // if an error occurs for a property with an enum type, the default error is "must have one of the allowed types."
+  // which is... unhelpful. `params.allowedValues` includes the allowed values. add this to the message if it exists
+  message = params.allowedValues ? `${message} - ${params.allowedValues.join(', ')}` : message
+
+  throw new SchemaValidationError(`${instancePath}: ${message}`)
 }
 
 export class SchemaValidationError extends Error { }

--- a/protocol/implementations/js/src/validator.ts
+++ b/protocol/implementations/js/src/validator.ts
@@ -3,7 +3,7 @@ import type { ErrorObject } from 'ajv'
 import * as compiledValidators from '../generated/compiled-validators.js'
 
 /**
- * 2-phased validation. validates the outer message first and then validates the body based on the value of payload.type
+ * 2-phased validation. validates the outer message first and then validates the body based on the value of `payload.type`
  * @param payload - the payload to validate
  */
 export function validateMessage(payload: any): void {

--- a/protocol/implementations/js/tbdex_schema_examples.js
+++ b/protocol/implementations/js/tbdex_schema_examples.js
@@ -1,50 +1,50 @@
 let offering = {
-  "description": "Buy BTC with USD!",
-  "pair": "BTC_USD",
-  "unitPrice": "27000.00",
-  "baseFee": "1.00",
-  "min": "10.00",
-  "max": "1000.00",
-  "presentationRequestJwt": "eyJhb...MIDw",
-  "payinInstruments": [{
-    "kind": "DEBIT_CARD",
-    "fee": {
-      "flatFee": "1.00"
+  'description'            : 'Buy BTC with USD!',
+  'pair'                   : 'BTC_USD',
+  'unitPrice'              : '27000.00',
+  'baseFee'                : '1.00',
+  'min'                    : '10.00',
+  'max'                    : '1000.00',
+  'presentationRequestJwt' : 'eyJhb...MIDw',
+  'payinInstruments'       : [{
+    'kind' : 'DEBIT_CARD',
+    'fee'  : {
+      'flatFee': '1.00'
     }
   }],
-  "payoutInstruments": [{
-    "kind": "BTC_ADDRESS"
+  'payoutInstruments': [{
+    'kind': 'BTC_ADDRESS'
   }]
 }
 
 let rfq = {
-  "pair": "BTC_USD",
-  "amount": "10.00",
-  "verifiablePresentationJwt": "...",
-  "payinInstrument": {
-    "kind": "DEBIT_CARD"
+  'pair'                      : 'BTC_USD',
+  'amount'                    : '10.00',
+  'verifiablePresentationJwt' : '...',
+  'payinInstrument'           : {
+    'kind': 'DEBIT_CARD'
   },
-  "payoutInstrument": {
-    "kind": "BTC_ADDRESS"
+  'payoutInstrument': {
+    'kind': 'BTC_ADDRESS'
   }
 }
 
 let quote = {
-  "expiryTime": "2023-04-14T12:12:12Z",
-  "totalFee": "2.00",
-  "amount": "0.000383",
-  "paymentPresentationRequestJwt": "eyJhbGc...EWfNnAw",
-  "paymentInstructions": {
-    "payin": {
-      "link": "stripe.com?for=alice"
+  'expiryTime'                    : '2023-04-14T12:12:12Z',
+  'totalFee'                      : '2.00',
+  'amount'                        : '0.000383',
+  'paymentPresentationRequestJwt' : 'eyJhbGc...EWfNnAw',
+  'paymentInstructions'           : {
+    'payin': {
+      'link': 'stripe.com?for=alice'
     }
   }
 }
 
 let order = {
-  "paymentVerifiablePresentationJwt": "..."
+  'paymentVerifiablePresentationJwt': '...'
 }
 
 let orderStatus = {
-  "orderStatus": "PENDING"
+  'orderStatus': 'PENDING'
 }

--- a/protocol/implementations/js/tests/validator.spec.ts
+++ b/protocol/implementations/js/tests/validator.spec.ts
@@ -5,8 +5,8 @@ import { SchemaValidationError, validateMessage } from '../src/validator.js'
 const validMessage = {
   'id'          : '123',
   'contextId'   : '123',
-  'from'        : 'test',
-  'to'          : 'test',
+  'from'        : 'did:swanky:alice',
+  'to'          : 'did:swanky:pfi',
   'createdTime' : '2023-04-14T12:12:12Z',
   'type'        : 'offering',
   'body'        : {
@@ -36,8 +36,8 @@ const validMessage = {
 const mismatchedBody = {
   'id'          : '123',
   'contextId'   : '123',
-  'from'        : 'test',
-  'to'          : 'test',
+  'from'        : 'did:swanky:alice',
+  'to'          : 'did:swanky:pfi',
   'createdTime' : '2023-04-14T12:12:12Z',
   'type'        : 'rfq',
   'body'        : {
@@ -48,9 +48,9 @@ const mismatchedBody = {
 const invalidType = {
   'id'          : '123',
   'contextId'   : '123',
-  'from'        : 'test',
-  'to'          : 'test',
-  'dateCreated' : 123,
+  'from'        : 'did:swanky:alice',
+  'to'          : 'did:swanky:pfi',
+  'createdTime' : 'whateva',
   'type'        : 'blah',
   'body'        : {
     'orderStatus': 'PENDING'
@@ -60,8 +60,8 @@ const invalidType = {
 const missingField = {
   'id'          : '123',
   'contextId'   : '123',
-  'from'        : 'test',
-  'to'          : 'test',
+  'from'        : 'did:swanky:alice',
+  'to'          : 'did:swanky:pfi',
   'createdTime' : '2023-04-14T12:12:12Z',
   'type'        : 'order',
   'body'        : {}
@@ -70,8 +70,8 @@ const missingField = {
 const numberAmounts = {
   'id'          : '123',
   'contextId'   : '123',
-  'from'        : 'test',
-  'to'          : 'test',
+  'from'        : 'did:swanky:alice',
+  'to'          : 'did:swanky:pfi',
   'createdTime' : '2023-04-14T12:12:12Z',
   'type'        : 'offering',
   'body'        : {
@@ -103,15 +103,39 @@ describe('validator', () => {
     expect(validateMessage(validMessage)).to.not.throw
   })
   it('throws error if message type does not match body', () => {
-    expect(() => validateMessage(mismatchedBody)).to.throw(SchemaValidationError)
+    try {
+      validateMessage(mismatchedBody)
+      expect.fail()
+    } catch(e) {
+      expect(e).to.be.instanceOf(SchemaValidationError)
+      expect(e.message).to.include('required')
+    }
   })
   it('throws error if unrecognized message type is passed', () => {
-    expect(() => validateMessage(invalidType)).to.throw(SchemaValidationError)
+    try {
+      validateMessage(invalidType)
+      expect.fail()
+    } catch(e) {
+      expect(e).to.be.instanceOf(SchemaValidationError)
+      expect(e.message).to.include('allowed values')
+    }
   })
   it('throws error if amount types are incorrect', () => {
-    expect(() => validateMessage(numberAmounts)).to.throw(SchemaValidationError)
+    try {
+      validateMessage(numberAmounts)
+      expect.fail()
+    } catch(e) {
+      expect(e).to.be.instanceOf(SchemaValidationError)
+      expect(e.message).to.include('must be')
+    }
   })
   it('throws error if required fields are missing', () => {
-    expect(() => validateMessage(missingField)).to.throw(SchemaValidationError)
+    try {
+      validateMessage(missingField)
+      expect.fail()
+    } catch(e) {
+      expect(e).to.be.instanceOf(SchemaValidationError)
+      expect(e.message).to.include('required')
+    }
   })
 })

--- a/protocol/implementations/json-schemas/definitions.json
+++ b/protocol/implementations/json-schemas/definitions.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tbdex.io/definitions.json",
+  "type": "object",
+  "definitions": {
+    "did": {
+      "type": "string",
+      "pattern": "^did:([a-z0-9]+):((?:(?:[a-zA-Z0-9._-]|(?:%[0-9a-fA-F]{2}))*:)*((?:[a-zA-Z0-9._-]|(?:%[0-9a-fA-F]{2}))+))((;[a-zA-Z0-9_.:%-]+=[a-zA-Z0-9_.:%-]*)*)(\/[^#?]*)?([?][^#]*)?(#.*)?$"
+    },
+    "paymentInstrument": {
+      "type": "object",
+      "required": ["kind"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "fee": {
+          "type": "object"
+        }
+      }
+    },
+    "paymentInstruction": {
+      "type": "object",
+      "properties": {
+        "link": {
+          "type": "string"
+        },
+        "instruction": {
+          "type": "string"
+        }
+      }
+    },
+    "paymentInstructions": {
+      "type": "object",
+      "properties": {
+        "payin": {
+          "$ref": "https://tbdex.io/definitions.json#/definitions/paymentInstruction"
+        },
+        "payout": {
+          "$ref": "https://tbdex.io/definitions.json#/definitions/paymentInstruction"
+        }
+      }
+    }
+  }
+}

--- a/protocol/implementations/json-schemas/message.schema.json
+++ b/protocol/implementations/json-schemas/message.schema.json
@@ -22,8 +22,7 @@
         "description": "The recipient's DID"
       },
       "type": {
-        "type": "string",
-        "enum": ["rfq", "quote"],
+        "enum": ["offering", "rfq", "quote", "order", "orderStatus"],
         "description": "The specific message type. Any of the message types documented under the Message Types section are considered valid"
       },
       "body": {

--- a/protocol/implementations/json-schemas/message.schema.json
+++ b/protocol/implementations/json-schemas/message.schema.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://tbdex.io/message.schema.json",
+    "type": "object",
+    "required": ["id", "contextId", "from", "to", "type", "body", "createdTime"],
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "type": "string",
+        "description": "The message ID"
+      },
+      "contextId": {
+        "type": "string",
+        "description": "Set by the first message in a thread. A message thread is defined as an initial message and its associated replies."
+      },
+      "from": {
+        "$ref": "https://tbdex.io/definitions.json#/definitions/did",
+        "description": "The sender's DID"
+      },
+      "to": {
+        "$ref": "https://tbdex.io/definitions.json#/definitions/did",
+        "description": "The recipient's DID"
+      },
+      "type": {
+        "type": "string",
+        "enum": ["rfq", "quote"],
+        "description": "The specific message type. Any of the message types documented under the Message Types section are considered valid"
+      },
+      "body": {
+        "type": "object",
+        "description": "The actual message content. The fields within `body` must adhere to the fields expected for the given message type"
+      },
+      "createdTime": {
+        "type": "string",
+        "description": "The creation time of the message. Expressed as ISO8601"
+      }
+    }
+  }
+  

--- a/protocol/implementations/json-schemas/offering.schema.json
+++ b/protocol/implementations/json-schemas/offering.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tbdex.io/offering.schema.json",
+  "type": "object",
+  "required": [
+    "description",
+    "pair",
+    "unitPrice",
+    "min",
+    "max",
+    "presentationRequestJwt",
+    "payinInstruments",
+    "payoutInstruments"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "pair": {
+      "type": "string"
+    },
+    "unitPrice": {
+      "type": "string"
+    },
+    "baseFee": {
+      "type": "string"
+    },
+    "min": {
+      "type": "string"
+    },
+    "max": {
+      "type": "string"
+    },
+    "presentationRequestJwt": {
+      "type": "string"
+    },
+    "payinInstruments": {
+      "type": "array",
+      "items": {
+        "$ref": "https://tbdex.io/definitions.json#/definitions/paymentInstrument"
+      }
+    },
+    "payoutInstruments": {
+      "type": "array",
+      "items": {
+        "$ref": "https://tbdex.io/definitions.json#/definitions/paymentInstrument"
+      }
+    }
+  }
+}

--- a/protocol/implementations/json-schemas/order-status.schema.json
+++ b/protocol/implementations/json-schemas/order-status.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tbdex.io/order-status.schema.json",
+  "type": "object",
+  "required": [
+    "orderStatus"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "orderStatus": {
+      "enum": [
+        "PENDING",
+        "COMPLETED",
+        "FAILED"
+      ]
+    }
+  }
+}

--- a/protocol/implementations/json-schemas/order.schema.json
+++ b/protocol/implementations/json-schemas/order.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tbdex.io/order.schema.json",
+  "type": "object",
+  "required": [
+    "paymentVerifiablePresentationJwt"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "paymentVerifiablePresentationJwt": {
+      "type": "string"
+    }
+  }
+}

--- a/protocol/implementations/json-schemas/quote.schema.json
+++ b/protocol/implementations/json-schemas/quote.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tbdex.io/quote.schema.json",
+  "type": "object",
+  "required": [
+    "expiryTime",
+    "totalFee",
+    "amount",
+    "paymentPresentationRequestJwt",
+    "paymentInstructions"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "expiryTime": {
+      "type": "string"
+    },
+    "totalFee": {
+      "type": "string"
+    },
+    "amount": {
+      "type": "string"
+    },
+    "paymentPresentationRequestJwt": {
+      "type": "string"
+    },
+    "paymentInstructions": {
+      "$ref": "https://tbdex.io/definitions.json#/definitions/paymentInstructions"
+    }
+  }
+}

--- a/protocol/implementations/json-schemas/rfq.schema.json
+++ b/protocol/implementations/json-schemas/rfq.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tbdex.io/rfq.schema.json",
+  "type": "object",
+  "required": [
+    "pair",
+    "amount",
+    "verifiablePresentationJwt",
+    "payinInstrument",
+    "payoutInstrument"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "pair": {
+      "type": "string"
+    },
+    "amount": {
+      "type": "string"
+    },
+    "verifiablePresentationJwt": {
+      "type": "string"
+    },
+    "payinInstrument": {
+      "$ref": "https://tbdex.io/definitions.json#/definitions/paymentInstrument"
+    },
+    "payoutInstrument": {
+      "$ref": "https://tbdex.io/definitions.json#/definitions/paymentInstrument"
+    }
+  }
+}
+  


### PR DESCRIPTION
This PR includes:

* Compiling message validators at compile/build time. 
    * Motivating factors behind doing this are:
        * to avoid dynamic code evaluation with Function constructor (used for schema compilation) - when it is prohibited by the browser page [Content Security Policy](https://ajv.js.org/security.html#content-security-policy). This applies to PWAs
        * prevents having to pack the json schemas themselves into the package. this gets weirdly tricky with `assert { type: 'json' }` and browser bundling gets even more 🤢 than it already is
    * Unintentional benefits: 
        *  reduces the browser bundle size - Ajv is not included in the bundle. bundle size isn't an issue right now. we basically got this for free
    * allegedly reduces the start-up time - the validation and compilation of schemas will happen during build time. didn't test the reduction myself, just something mentioned in the [Ajv docs](https://ajv.js.org/guide/managing-schemas.html#standalone-validation-code)
* Removal of polyfills from browser bundle since they aren't needed
* Exports dwn protocol definitions
* Splits schemas out into separate files. initially did this to chase down a bug. Ended up feeling like it was a bit easier to read
* modified `validateMessage` to do 2-phase validation. validates the outer message first and then validates the body based on the value of `payload.type`.
    * we have an issue open to return all errors instead of just the first one (#92). This is sort of in preparation for that. if `type` is not one of the expected message types, `body` would still be tested against each message type. the single schema approach understandably used `oneOf` which means each message type would have been attempted
    * Error messages end up being more readable (100% subjective)