### PR TITLE
Removed empty actions causing protocol configuration error

### DIFF
--- a/protocol/implementations/js/package-lock.json
+++ b/protocol/implementations/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/tbdex",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/tbdex",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "8.12.0",

--- a/protocol/implementations/js/package.json
+++ b/protocol/implementations/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/tbdex",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "description": "Library that includes type definitions for tbdex messages",
   "license": "Apache-2.0",

--- a/protocol/implementations/js/src/main.ts
+++ b/protocol/implementations/js/src/main.ts
@@ -1,4 +1,4 @@
 export * from './types.js'
 export * from './builders.js'
 export * from './validator.js'
-export * from './protocolDefinitions.js'
+export * from './protocol-definitions.js'

--- a/protocol/implementations/js/src/protocol-definitions.ts
+++ b/protocol/implementations/js/src/protocol-definitions.ts
@@ -29,9 +29,8 @@ export const aliceProtocolDefinition = {
   structure: {
     // alice sends RFQs, not receives them
     RFQ: {
-      $actions : [],
       // whoever received the RFQ that Alice sent, can write back a Quote to Alice
-      Quote    : {
+      Quote: {
         $actions: [
           {
             who : 'recipient',
@@ -41,9 +40,8 @@ export const aliceProtocolDefinition = {
         ],
         // alice sends Orders, not receives them
         Order: {
-          $actions    : [],
           // whoever received the order that Alice sent in response to a Quote in response to an RFQ, can write back an OrderStatus to Alice.
-          OrderStatus : {
+          OrderStatus: {
             $actions: [
               {
                 who : 'recipient',
@@ -99,10 +97,9 @@ export const pfiProtocolDefinition = {
       ],
       // PFI is sending OUT quotes. no one should be writing Quotes to PFIs.
       Quote: {
-        $actions : [],
         // only Alice, who received an RFQ/Quote, can write Order to PFIs DWN
         // no one can read Order from PFIs DWN (except the PFI itself)
-        Order    : {
+        Order: {
           $actions: [
             {
               who : 'recipient',
@@ -111,9 +108,7 @@ export const pfiProtocolDefinition = {
             }
           ],
           // PFI is sending OUT OrderStatus. no one should be writing OrderStatus to PFIs.
-          OrderStatus: {
-            $actions: []
-          }
+          OrderStatus: { }
         }
       }
     }


### PR DESCRIPTION
Also renamed file to be consistent w/ broader naming conventions: from `protocolDefinitions.ts` to `protocol-definitions.ts`

---

Trying to use the protocol definitions w/ an actual DWN instance (from the `dwn-sdk-js` package), and was getting the following error...

```
file:///Users/kendallw/Development/workspace/tbdollars/dwn-proxy/node_modules/@tbd54566975/dwn-sdk-js/dist/esm/src/schema-validator.js:25
    throw new Error(`${instancePath}: ${message}`);
          ^

Error: /descriptor/definition/structure/RFQ/Quote/$actions: must NOT have fewer than 1 items
    at validateJsonSchema (file:///Users/kendallw/Development/workspace/tbdollars/dwn-proxy/node_modules/@tbd54566975/dwn-sdk-js/dist/esm/src/schema-validator.js:25:11)
    at Message.validateJsonSchema (file:///Users/kendallw/Development/workspace/tbdollars/dwn-proxy/node_modules/@tbd54566975/dwn-sdk-js/dist/esm/src/core/message.js:58:9)
    at ProtocolsConfigure.<anonymous> (file:///Users/kendallw/Development/workspace/tbdollars/dwn-proxy/node_modules/@tbd54566975/dwn-sdk-js/dist/esm/src/interfaces/protocols/messages/protocols-configure.js:34:21)
    at Generator.next (<anonymous>)
    at fulfilled (file:///Users/kendallw/Development/workspace/tbdollars/dwn-proxy/node_modules/@tbd54566975/dwn-sdk-js/dist/esm/src/interfaces/protocols/messages/protocols-configure.js:4:58)

Node.js v19.8.1
```

Apparently we're not supposed to have empty `$actions: []` arrays. I'm guessing this is there for good reason, and we should work to resolve the underlying issue... but for now, we can get around it by merely removing the `$actions` property. Open to not doing this, but thinking pragmatically here.