### PR TITLE
change type of `PaymentMethod.kind` to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,31 +21,31 @@ Messages form exchanges between users and PFIs.
 ## `Offering`
 > PFI -> world: "Here are the exchanges that my PFI offers. These are the constraints of my offer in terms of how much you can buy, what credentials I need from you, and what payment methods you can use to pay me the base currency, and what payment methods I can use to pay you the quote currency."
 
-| field            | data type | required | description                                                                                          |
-| ---------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `id` | string    | Y        | Unique identifier for this offering|
-| `description` | string    | Y        | Brief description of what is being offered.|
-| `baseCurrency` | string | Y | Currency that the PFI is selling. |
-| `quoteCurrency` | string | Y | Currency that the PFI is accepting as payment for `baseCurrency`. |
-| `unitPrice` | string    | Y        | How much `quoteCurrency` is required for PFI to sell 1 unit of `baseCurrency`.|
-| `baseFee`   | string       | N        | Optional base fee associated with this offering, regardless of which payment methods are used |
-| `min`   | string       | Y        | Minimum amount of quote currency that the counterparty (Alice) must submit in order to qualify for this offering.|
-| `max`   | string       | Y        | Maximum amount of quote currency that the counterparty (Alice) can submit in order to qualify for this offering.|
-| `kycRequirements`   | string    | Y        |  PresentationDefinition in JWT string format which describes the credential needed to choose this offer.|
-| `payinMethods`   | list[PaymentMethod]    | Y        |  A list of payment methods the counterparty (Alice) can choose to send payment to the PFI from in order to qualify for this offering.|
-| `payoutMethods`   | list[PaymentMethod]    | Y        |  A list of payment methods the counterparty (Alice) can choose to receive payment from the PFI in order to qualify for this offering.|
-| `createdTime` | datetime        | Y              | The creation time of the resource. Expressed as ISO8601|
+| field             | data type           | required | description                                                                                                                          |
+| ----------------- | ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`              | string              | Y        | Unique identifier for this offering                                                                                                  |
+| `description`     | string              | Y        | Brief description of what is being offered.                                                                                          |
+| `baseCurrency`    | string              | Y        | Currency that the PFI is selling.                                                                                                    |
+| `quoteCurrency`   | string              | Y        | Currency that the PFI is accepting as payment for `baseCurrency`.                                                                    |
+| `unitPrice`       | string              | Y        | How much `quoteCurrency` is required for PFI to sell 1 unit of `baseCurrency`.                                                       |
+| `baseFee`         | string              | N        | Optional base fee associated with this offering, regardless of which payment methods are used                                        |
+| `min`             | string              | Y        | Minimum amount of quote currency that the counterparty (Alice) must submit in order to qualify for this offering.                    |
+| `max`             | string              | Y        | Maximum amount of quote currency that the counterparty (Alice) can submit in order to qualify for this offering.                     |
+| `kycRequirements` | string              | Y        | PresentationDefinition in JWT string format which describes the credential needed to choose this offer.                              |
+| `payinMethods`    | list[PaymentMethod] | Y        | A list of payment methods the counterparty (Alice) can choose to send payment to the PFI from in order to qualify for this offering. |
+| `payoutMethods`   | list[PaymentMethod] | Y        | A list of payment methods the counterparty (Alice) can choose to receive payment from the PFI in order to qualify for this offering. |
+| `createdTime`     | datetime            | Y        | The creation time of the resource. Expressed as ISO8601                                                                              |
 
 
 ## Note on `baseCurrency` and `quoteCurrency`
 Base Currency is the currency that the PFI is **selling**. Quote currency is the currency that the PFI is willing to accept to sell the base currency. In other words, PFI is **buying** the quote currency. In trading terms, the PFI's side is always `SELL` (selling base currency). Conversely, Alice's side is always `BUY` (buying base currency)
 
 ### `Offering.PaymentMethod`
-| field            | data type | required | description                                                                                          |
-| ---------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `kind` | enum    | Y        | Type of payment method (i.e. `DEBIT_CARD`, `BITCOIN_ADDRESS`, `SQUARE_PAY`)|
-| `paymentPresentationDefinitionJwt`     | string   | N        | PresentationDefinition that describes the VCs needed to use this PaymentMethod in JWT string format|
-| `fee` | object    | N        | Optional fee associated with using this kind of payment method.|
+| field                              | data type | required | description                                                                                         |
+| ---------------------------------- | --------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `kind`                             | string    | Y        | Type of payment method (i.e. `DEBIT_CARD`, `BITCOIN_ADDRESS`, `SQUARE_PAY`)                         |
+| `paymentPresentationDefinitionJwt` | string    | N        | PresentationDefinition that describes the VCs needed to use this PaymentMethod in JWT string format |
+| `fee`                              | object    | N        | Optional fee associated with using this kind of payment method.                                     |
 
 
 ```json
@@ -85,8 +85,8 @@ In any case, PFIs implementing this protocol should consider the fields below.
 
 Every TBDex message contains the following fields:
 
-| Field         | Data Type     | Required (y/n) | Description                                                                                                                           |
-| ------------- | ------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Field         | Data Type   | Required (y/n) | Description                                                                                                                           |
+| ------------- | ----------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `id`          | string      | Y              | The message ID                                                                                                                        |
 | `threadId`    | string      | Y              | The thread ID. Set by the first message in a conversation. A message thread is defined an initial message and its associated replies. |
 | `parentId`    | string      | Y              | The ID of the last message in the thread.                                                                                             |
@@ -94,7 +94,7 @@ Every TBDex message contains the following fields:
 | `to`          | string      | Y              | The recipient's DID                                                                                                                   |
 | `type`        | string      | Y              | The specific message type. Any of the message types documented under the [Message Types](#message-types) section are considered valid |
 | `body`        | JSON Object | Y              | The actual message content. the fields within `body` must adhere to the fields expected for the given message type                    |
-| `createdTime` | datetime    | Y              | The creation time of the message. Expressed as ISO8601|
+| `createdTime` | datetime    | Y              | The creation time of the message. Expressed as ISO8601                                                                                |
 
 
 # ID for each message types
@@ -106,20 +106,20 @@ The `body` of each message can be any of the following message types.
 ## `RFQ (Request For Quote)`
 > Alice -> PFI: "OK, that offering looks good. Give me a Quote against that Offering, and here is how much USD I want to trade for BTC. Here is my proof of KYC, the payment method I intend to pay you USD with, and the payment method I expect you to pay me BTC in."
 
-| field            | data type | required | description                                                                                          |
-| ---------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `baseCurrency` | string | Y | Currency that the PFI is selling. |
-| `quoteCurrency` | string | Currency that the PFI is accepting as payment for `baseCurrency`. |
-| `amount` | string    | Y        | Amount of quote currency you want to spend in order to receive base currency|
-| `kycProof` | string    | Y        | VerifiablePresentation in JWT string format that meets the specification per PresentationDefinition in the Offering|
-| `payinMethod`   | PaymentMethodResponse       | Y        | Specify which payment method to send quote currency. |
-| `payoutMethod`   | PaymentMethodResponse       | Y        | Specify which payment method to receive base currency. |
+| field           | data type             | required                                                          | description                                                                                                         |
+| --------------- | --------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `baseCurrency`  | string                | Y                                                                 | Currency that the PFI is selling.                                                                                   |
+| `quoteCurrency` | string                | Currency that the PFI is accepting as payment for `baseCurrency`. |
+| `amount`        | string                | Y                                                                 | Amount of quote currency you want to spend in order to receive base currency                                        |
+| `kycProof`      | string                | Y                                                                 | VerifiablePresentation in JWT string format that meets the specification per PresentationDefinition in the Offering |
+| `payinMethod`   | PaymentMethodResponse | Y                                                                 | Specify which payment method to send quote currency.                                                                |
+| `payoutMethod`  | PaymentMethodResponse | Y                                                                 | Specify which payment method to receive base currency.                                                              |
 
 ### `RFQ.PaymentMethodResponse`
-| field            | data type | required | description                                                                                          |
-| ---------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `kind` | enum    | Y        | Type of payment method (i.e. `DEBIT_CARD`, `BITCOIN_ADDRESS`, `SQUARE_PAY`)|
-| `paymentVerifiablePresentationJwt`     | string   | N        | VerifiablePresentation in JWT string format that meets the specification per paymentPresentationDefinition in the Offering.|
+| field                              | data type | required | description                                                                                                                 |
+| ---------------------------------- | --------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `kind`                             | string    | Y        | Type of payment method (i.e. `DEBIT_CARD`, `BITCOIN_ADDRESS`, `SQUARE_PAY`)                                                 |
+| `paymentVerifiablePresentationJwt` | string    | N        | VerifiablePresentation in JWT string format that meets the specification per paymentPresentationDefinition in the Offering. |
 
 ```json
 {
@@ -140,24 +140,24 @@ The `body` of each message can be any of the following message types.
 ## `Quote`
 > PFI -> Alice: "OK, here's your Quote that describes how much BTC you will receive based on your RFQ. Here's the total fee in USD associated with the payment methods you selected. Here's how to pay us, and how to let us pay you, when you're ready to execute the Quote. This quote expires at X time."
 
-| field            | data type   | required | description                                                   |
-| ---------------- | ----------- | -------- | ------------------------------------------------------------- |
-| `expiryTime`     | datetime         | Y        | When this quote expires. Expressed as ISO8601|
-| `totalFee`     | string         | Y        | Total fee (base + PaymentMethod specific) included in quote in quote currency.|
-| `amount`     | string         | Y        | Amount of base currency that the PFI is willing to sell in exchange for quote currency `amount` in the original RFQ|
-| `paymentInstructions`     | PaymentInstructions   | N        | Object that describes how to pay the PFI, and how to get paid by the PFI, in the instances where payment is performed "out-of-band" (e.g. PFI cannot be both a merchant and a payment processor simultaneously) |
+| field                 | data type           | required | description                                                                                                                                                                                                     |
+| --------------------- | ------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `expiryTime`          | datetime            | Y        | When this quote expires. Expressed as ISO8601                                                                                                                                                                   |
+| `totalFee`            | string              | Y        | Total fee (base + PaymentMethod specific) included in quote in quote currency.                                                                                                                                  |
+| `amount`              | string              | Y        | Amount of base currency that the PFI is willing to sell in exchange for quote currency `amount` in the original RFQ                                                                                             |
+| `paymentInstructions` | PaymentInstructions | N        | Object that describes how to pay the PFI, and how to get paid by the PFI, in the instances where payment is performed "out-of-band" (e.g. PFI cannot be both a merchant and a payment processor simultaneously) |
 
 ### `Quote.PaymentInstructions`
-| field            | data type | required | description                                                                                          |
-| ---------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `payin` | PaymentInstruction    | N        | Link or Instruction describing how to pay the PFI. |
-| `payout` | PaymentInstruction    | N        | Link or Instruction describing how to get paid by the PFI|
+| field    | data type          | required | description                                               |
+| -------- | ------------------ | -------- | --------------------------------------------------------- |
+| `payin`  | PaymentInstruction | N        | Link or Instruction describing how to pay the PFI.        |
+| `payout` | PaymentInstruction | N        | Link or Instruction describing how to get paid by the PFI |
 
 ### `Quote.PaymentInstructions.PaymentInstruction`
-| field            | data type | required | description                                                                                          |
-| ---------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `link` | String    | N        | Link to allow Alice to pay PFI, or be paid by the PFI |
-| `instruction` | String    | N        | Instruction on how Alice can pay PFI, or how Alice can be paid by the PFI|
+| field         | data type | required | description                                                               |
+| ------------- | --------- | -------- | ------------------------------------------------------------------------- |
+| `link`        | String    | N        | Link to allow Alice to pay PFI, or be paid by the PFI                     |
+| `instruction` | String    | N        | Instruction on how Alice can pay PFI, or how Alice can be paid by the PFI |
 
 
 ```json
@@ -176,8 +176,8 @@ The `body` of each message can be any of the following message types.
 ## `OrderStatus`
 > PFI -> Alice: "Here's the status of your order."
 
-| field             | data type   | required | description                                                                             |
-| ----------------- | ----------- | -------- | --------------------------------------------------------------------------------------- |
+| field         | data type | required | description                                   |
+| ------------- | --------- | -------- | --------------------------------------------- |
 | `orderStatus` | enum      | Y        | Current status of Order that's being executed |
 
 ```json
@@ -212,16 +212,16 @@ sequenceDiagram
 
 # Resources
 
-| Resource Name                                                                                       | Description                                                                |
+| Resource Name                                                                                    | Description                                                                   |
 | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
 | [CODEOWNERS](https://github.com/TBD54566975/tbdex-protocol/blob/main/CODEOWNERS)                 | Outlines the project lead(s)                                                  |
 | [CODE_OF_CONDUCT.md](https://github.com/TBD54566975/tbdex-protocol/blob/main/CODE_OF_CONDUCT.md) | Expected behavior for project contributors, promoting a welcoming environment |
 | [CONTRIBUTING.md](https://github.com/TBD54566975/tbdex-protocol/blob/main/CONTRIBUTING.md)       | Developer guide to build, test, run, access CI, chat, discuss, file issues    |
 | [GOVERNANCE.md](https://github.com/TBD54566975/tbdex-protocol/blob/main/GOVERNANCE.md)           | Project governance                                                            |
 | [LICENSE](https://github.com/TBD54566975/tbdex-protocol/blob/main/LICENSE)                       | Apache License, Version 2.0                                                   |
-| [tbDEX whitepaper](https://tbdex.io/whitepaper.pdf)                       | tbDEX whitepaper                                                   |
-| [Decentralized Web Node SDK](https://github.com/TBD54566975/dwn-sdk-js)                       | dwn-sdk-js library                                                   |
-| [DWN Server](https://github.com/TBD54566975/dwn-server) | Full implementation of dwn-sdk-js |
-| [Self Soverign Identity SDK](https://github.com/TBD54566975/ssi-sdk)                       | SSI SDK                                                   |
-| [SSI Service](https://github.com/TBD54566975/ssi-service)                       | Full implementation of ssi-sdk                                                   |
+| [tbDEX whitepaper](https://tbdex.io/whitepaper.pdf)                                              | tbDEX whitepaper                                                              |
+| [Decentralized Web Node SDK](https://github.com/TBD54566975/dwn-sdk-js)                          | dwn-sdk-js library                                                            |
+| [DWN Server](https://github.com/TBD54566975/dwn-server)                                          | Full implementation of dwn-sdk-js                                             |
+| [Self Soverign Identity SDK](https://github.com/TBD54566975/ssi-sdk)                             | SSI SDK                                                                       |
+| [SSI Service](https://github.com/TBD54566975/ssi-service)                                        | Full implementation of ssi-sdk                                                |
 | [LICENSE](https://github.com/TBD54566975/tbdex-protocol/blob/main/LICENSE)                       | Apache License, Version 2.0                                                   |

--- a/protocol/implementations/js/package.json
+++ b/protocol/implementations/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/tbdex",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "description": "Library that includes type definitions for tbdex messages",
   "license": "Apache-2.0",

--- a/protocol/implementations/js/src/types.ts
+++ b/protocol/implementations/js/src/types.ts
@@ -22,24 +22,18 @@ export interface Offering {
 }
 
 export interface PaymentMethod {
-  kind: PaymentMethodKind,
+  kind: string
   paymentPresentationRequestJwt?: string
   fee?: {
     flatFee?: string
   }
 }
 
-export enum PaymentMethodKind {
-  DEBIT_CARD,
-  BITCOIN_ADDRESS,
-  SQUARE_PAY
-}
-
 export type MessageType<M extends keyof MessageTypes> = MessageTypes[M]
 
 export type MessageTypes = {
-  rfq: Rfq,
-  quote: Quote,
+  rfq: Rfq
+  quote: Quote
   orderStatus: OrderStatus
 }
 
@@ -66,7 +60,7 @@ export interface Rfq {
 }
 
 export interface PaymentMethodResponse {
-  kind: PaymentMethodKind,
+  kind: string
   paymentVerifiablePresentationJwt?: string
 }
 

--- a/protocol/implementations/js/tests/builders.spec.ts
+++ b/protocol/implementations/js/tests/builders.spec.ts
@@ -1,5 +1,6 @@
+import type { Quote, Rfq } from '../src/types.js'
+
 import { expect } from 'chai'
-import { Quote, Rfq, PaymentMethodKind } from '../src/types.js'
 import { createMessage } from '../src/builders.js'
 
 describe('messages builders', () => {
@@ -9,11 +10,11 @@ describe('messages builders', () => {
       amount      : '1000',
       kycProof    : 'fake-jwt',
       payinMethod : {
-        kind                             : PaymentMethodKind.DEBIT_CARD,
+        kind                             : 'DEBIT_CARD',
         paymentVerifiablePresentationJwt : ''
       },
       payoutMethod: {
-        kind                             : PaymentMethodKind.BITCOIN_ADDRESS,
+        kind                             : 'BITCOIN_ADDRESS',
         paymentVerifiablePresentationJwt : ''
       }
     }
@@ -34,11 +35,11 @@ describe('messages builders', () => {
       amount      : '1000',
       kycProof    : 'fake-jwt',
       payinMethod : {
-        kind                             : PaymentMethodKind.DEBIT_CARD,
+        kind                             : 'DEBIT_CARD',
         paymentVerifiablePresentationJwt : 'fake-debitcard-jwt'
       },
       payoutMethod: {
-        kind                             : PaymentMethodKind.BITCOIN_ADDRESS,
+        kind                             : 'BITCOIN_ADDRESS',
         paymentVerifiablePresentationJwt : 'fake-btcaddress-jwt'
       }
     }


### PR DESCRIPTION
Motivation behind this PR is two-fold:
* serializing a typescript enum returns a number with no context or meaning! e.g.

![image](https://github.com/TBD54566975/tbdex-protocol/assets/4887440/0607c977-dad3-40db-8577-19be5f8866fa)


though, we can definitely do something like this if we want:

![image](https://github.com/TBD54566975/tbdex-protocol/assets/4887440/87831b2c-9140-4cfa-aee9-19cb24c5d286)


* hardcoding `kind`s limits the types of payment methods people can use with tbDEX. If someone wanted to use another payment method kind e.g. `MOMO` (mobile money), they'd have to come submit a PR to this repo.
