### PR TITLE
bump `pex-models` version

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@tbd54566975/tbdex",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/tbdex",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "license": "Apache-2.0",
       "dependencies": {
-        "@sphereon/pex-models": "2.0.2",
+        "@sphereon/pex-models": "2.0.3",
         "ajv": "8.12.0",
         "ulidx": "2.0.0"
       },
@@ -625,9 +625,9 @@
       "dev": true
     },
     "node_modules/@sphereon/pex-models": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@sphereon/pex-models/-/pex-models-2.0.2.tgz",
-      "integrity": "sha512-ptHM72tdQrhMYSItHoGCm3HgK+HGF6tI29zYfS47H3M7ZjKhBgfmVHohuxhxA0Q6cL5gqH1jEA8G5Z2tadHmTw=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@sphereon/pex-models/-/pex-models-2.0.3.tgz",
+      "integrity": "sha512-NsPeYmJLhxRG5fJxpcHnRR3xvi7i8SK8s21kYR9oBWO8cBU9qBCpw3gdUNiyI01/h6fbYqkIZ7eBNsHBIzqk5Q=="
     },
     "node_modules/@types/chai": {
       "version": "4.3.5",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/tbdex",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "description": "Library that includes type definitions for tbdex messages",
   "license": "Apache-2.0",
@@ -51,7 +51,7 @@
   "dependencies": {
     "ajv": "8.12.0",
     "ulidx": "2.0.0",
-    "@sphereon/pex-models": "2.0.2"
+    "@sphereon/pex-models": "2.0.3"
   },
   "devDependencies": {
     "@playwright/test": "1.34.3",


### PR DESCRIPTION
to incorporate [this change](https://github.com/Sphereon-Opensource/pex-openapi/pull/28). This change is what allows us to dynamically render forms that use human readable input labels instead of what we currently have which is this:

![image](https://github.com/TBD54566975/tbdex-protocol/assets/4887440/01166b88-bc65-43ae-b0ff-5a79c093df96)
