### PR TITLE
Implement `verifyClaims`

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ An `Offering` is used by the PFI to describe a currency pair they have to _offer
 | `quoteUnitsPerBaseUnit` | string                                                                                                   | Y        | Number of quote units on offer for one base currency unit (i.e 290000 USD for 1 BTC                                                  |
 | `baseCurrency`          | [`CurrencyDetails`](#currencydetails)                                                                    | Y        | Details about the currency that the PFI is selling.                                                                                  |
 | `quoteCurrency`         | [`CurrencyDetails`](#currencydetails)                                                                    | Y        | Details about the currency that the PFI is accepting as payment for `baseCurrency`.                                                  |
-| `vcRequirements`        | [`PresentationDefinitionV2`](https://identity.foundation/presentation-exchange/#presentation-definition) | Y        | Articulates the credential(s) required when submitting an RFQ for this offering.                                                     |
+| `requiredClaims`        | [`PresentationDefinitionV2`](https://identity.foundation/presentation-exchange/#presentation-definition) | Y        | Articulates the claim(s) required when submitting an RFQ for this offering.                                                          |
 | `payinMethods`          | [`PaymentMethod[]`](#paymentmethod)                                                                      | Y        | A list of payment methods the counterparty (Alice) can choose to send payment to the PFI from in order to qualify for this offering. |
 | `payoutMethods`         | [`PaymentMethod[]`](#paymentmethod)                                                                      | Y        | A list of payment methods the counterparty (Alice) can choose to receive payment from the PFI in order to qualify for this offering. |
 | `createdAt`             | datetime                                                                                                 | Y        | The creation time of the resource. Expressed as ISO8601                                                                              |
@@ -385,13 +385,13 @@ Base64-encoded data is safe for transmission over most protocols and systems sin
 ### `RFQ (Request For Quote)`
 > Alice -> PFI: "OK, that offering looks good. Give me a Quote against that Offering, and here is how much USD (quote currency) I want to trade for BTC (base currency). Here are the credentials you're asking for, the payment method I intend to pay you USD with, and the payment method I expect you to pay me BTC in."
 
-| field                 | data type                                         | required | description                                                                                                         |
-| --------------------- | ------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
-| `offeringId`          | string                                            | Y        | Offering which Alice would like to get a quote for                                                                  |
-| `quoteAmountSubunits` | string                                            | Y        | Amount of quote currency you want to spend in order to receive base currency                                        |
-| `vcs`                 | string                                            | Y        | VerifiablePresentation in JWT string format that meets the specification per PresentationDefinition in the Offering |
-| `payinMethod`         | [`SelectedPaymentMethod`](#selectedpaymentmethod) | Y        | Specify which payment method to send quote currency.                                                                |
-| `payoutMethod`        | [`SelectedPaymentMethod`](#selectedpaymentmethod) | Y        | Specify which payment method to receive base currency.                                                              |
+| field                 | data type                                         | required | description                                                                           |
+| --------------------- | ------------------------------------------------- | -------- | ------------------------------------------------------------------------------------- |
+| `offeringId`          | string                                            | Y        | Offering which Alice would like to get a quote for                                    |
+| `quoteAmountSubunits` | string                                            | Y        | Amount of quote currency you want in exchange for base currency                       |
+| `claims`              | string[]                                          | Y        | an array of claims that fulfill the requirements declared in an [Offering](#offering) |
+| `payinMethod`         | [`SelectedPaymentMethod`](#selectedpaymentmethod) | Y        | Specify which payment method to send quote currency.                                  |
+| `payoutMethod`        | [`SelectedPaymentMethod`](#selectedpaymentmethod) | Y        | Specify which payment method to receive base currency.                                |
 
 #### `SelectedPaymentMethod`
 | field            | data type | required | description                                                                                       |

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -45,7 +45,7 @@
         "sinon": "15.0.2",
         "typedoc": "0.25.0",
         "typedoc-plugin-markdown": "3.16.0",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -6410,16 +6410,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/ua-parser-js": {

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/tbdex",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/tbdex",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "1.3.2",

--- a/js/package.json
+++ b/js/package.json
@@ -85,12 +85,12 @@
     "sinon": "15.0.2",
     "typedoc": "0.25.0",
     "typedoc-plugin-markdown": "3.16.0",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "scripts": {
     "clean": "rimraf generated dist tests/compiled",
     "compile-validators": "rimraf generated && node build/compile-validators.js",
-    "build:esm": "rimraf dist/esm dist/types && npx tsc -p tsconfig.json",
+    "build:esm": "rimraf dist/esm dist/types && tsc",
     "build:cjs": "rimraf dist/cjs && npx tsc -p tsconfig.cjs.json && echo '{\"type\": \"commonjs\"}' > ./dist/cjs/package.json",
     "build:browser": "rimraf dist/browser.mjs dist/browser.js && node build/bundles.js",
     "test:node": "rimraf tests/compiled && npm run compile-validators && tsc -p tests/tsconfig.json && mocha",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/tbdex",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "description": "Library that includes type definitions for tbdex messages",
   "license": "Apache-2.0",

--- a/js/src/dev-tools.ts
+++ b/js/src/dev-tools.ts
@@ -8,7 +8,7 @@ import { Convert } from '@web5/common'
 import { Rfq } from './message-kinds/index.js'
 import { Offering } from './resource-kinds/index.js'
 import { Crypto } from './crypto.js'
-import { OfferingModel, RfqModel } from './types.js'
+import { OfferingData, RfqData } from './types.js'
 
 export type DidMethodOptions = 'key' | 'ion'
 
@@ -61,7 +61,7 @@ export class DevTools {
    * creates and returns an example offering. Useful for testing purposes
    */
   static createOffering() {
-    const offeringData: OfferingModel = {
+    const offeringData: OfferingData = {
       description  : 'Selling BTC for USD',
       baseCurrency : {
         currencyCode : 'BTC',
@@ -118,7 +118,7 @@ export class DevTools {
           additionalProperties : false
         }
       }],
-      vcRequirements: {
+      requiredClaims: {
         id                : '7ce4004c-3c38-4853-968b-e411bafcd945',
         input_descriptors : [{
           id          : 'bbdb9b7c-5754-4f46-b63b-590bada959e0',
@@ -146,11 +146,11 @@ export class DevTools {
    * creates and returns an example rfq for the offering returned by {@link DevTools.createOffering}.
    * Useful for testing purposes.
    *
-   * **NOTE**: generates a random credential that fulfills the vcRequirements of the offering
+   * **NOTE**: generates a random credential that fulfills the offering's required claims
    */
   static async createRfq(opts: RfqOptions) {
     const { sender } = opts
-    const { signedCredential: _signedCredential } = await DevTools.createCredential({
+    const { signedCredential } = await DevTools.createCredential({
       type    : 'YoloCredential',
       issuer  : sender,
       subject : sender.did,
@@ -159,7 +159,7 @@ export class DevTools {
       }
     })
 
-    const rfqData: RfqModel = {
+    const rfqData: RfqData = {
       offeringId  : 'abcd123',
       payinMethod : {
         kind           : 'DEBIT_CARD',
@@ -177,7 +177,7 @@ export class DevTools {
         }
       },
       quoteAmountSubunits : '20000',
-      vcs                 : ''
+      claims              : [signedCredential]
     }
 
     return Rfq.create({

--- a/js/src/did-resolver.ts
+++ b/js/src/did-resolver.ts
@@ -55,7 +55,6 @@ export async function deferenceDidUrl(didUrl: string): Promise<DidResource> {
   // create a set of possible id matches. the DID spec allows for an id to be the entire did#fragment or just #fragment.
   // See: https://www.w3.org/TR/did-core/#relative-did-urls
   // using a set for fast string comparison. DIDs can be lonnng.
-  // TODO: check to see if parsedDid.fragment includes a '#'
   const idSet = new Set([didUrl, parsedDid.fragment, `#${parsedDid.fragment}`])
 
   for (let vm of verificationMethod) {

--- a/js/src/message-kinds/close.ts
+++ b/js/src/message-kinds/close.ts
@@ -7,9 +7,7 @@ export type CreateCloseOptions = {
   metadata: Omit<MessageMetadata<'close'>, 'id' |'kind' | 'createdAt'>
 }
 
-/**
- * a Close can be sent by Alice or the PFI as a reply to an RFQ or a Quote
- */
+/** a Close can be sent by Alice or the PFI as a reply to an RFQ or a Quote */
 export class Close extends Message<'close'> {
   /** a set of valid Message kinds that can come after a close */
   readonly validNext = new Set<MessageKind>([])

--- a/js/src/message-kinds/order.ts
+++ b/js/src/message-kinds/order.ts
@@ -7,6 +7,7 @@ export type CreateOrderOptions = {
   private?: Record<string, any>
 }
 
+/** Message sent by Alice to the PFI to accept a Quote. */
 export class Order extends Message<'order'> {
   readonly validNext = new Set<MessageKind>(['orderstatus'])
 

--- a/js/src/message-kinds/rfq.ts
+++ b/js/src/message-kinds/rfq.ts
@@ -52,16 +52,16 @@ export class Rfq extends Message<'rfq'> {
     // TODO: validate rfq's payoutMethod.kind against offering's payoutMethods
     // TODO: validate rfq's payoutMethod.paymentDetails against offering's respective requiredPaymentDetails json schema
 
-    this.verifyCredentialRequirements(offering)
+    this.verifyClaims(offering)
   }
 
   /**
-   * checks the claims provided in this rfq against the provided offering's requirements
+   * checks the claims provided in this rfq against an offering's requirements
    * @param offering - the offering to check against
-   * @throws
+   * @throws if rfq's claims do not fulfill the offering's requirements
    */
-  verifyCredentialRequirements(offering: Offering | ResourceModel<'offering'>) {
-    const { areRequiredCredentialsPresent } = pex.evaluatePresentation(offering.data.vcRequirements, this.vcs)
+  verifyClaims(offering: Offering | ResourceModel<'offering'>) {
+    const { areRequiredCredentialsPresent } = pex.evaluateCredentials(offering.data.requiredClaims, this.claims)
 
     if (areRequiredCredentialsPresent === 'error') {
       throw new Error(`claims do not fulfill the offering's requirements`)
@@ -81,8 +81,8 @@ export class Rfq extends Message<'rfq'> {
   }
 
   /** Presentation Submission VP that fulfills the requirements included in the respective Offering */
-  get vcs() {
-    return this.data.vcs
+  get claims() {
+    return this.data.claims
   }
 
   /** Selected payment method that Alice will use to send the listed quote currency to the PFI. */

--- a/js/src/message.ts
+++ b/js/src/message.ts
@@ -88,8 +88,8 @@ export class Message<T extends MessageKind> {
   /**
    * signs the message as a jws with detached content and sets the signature property
    * @param privateKeyJwk - the key to sign with
-   * @param kid - the kid to include in the jws header. used by the verifier to select the appropriate verificationMethod
-   *              when dereferencing the signer's DID
+   * @param kid - the verification method id to include in the jws header. used by the verifier to
+   *               select the appropriate verificationMethod when dereferencing the signer's DID
    */
   async sign(privateKeyJwk: Web5PrivateKeyJwk, kid: string): Promise<void> {
     const toSign = { metadata: this.metadata, data: this.data }

--- a/js/src/pfi-rest-api/client.ts
+++ b/js/src/pfi-rest-api/client.ts
@@ -1,4 +1,4 @@
-import type { ResourceMetadata, MessageModel, OfferingModel, ResourceModel, MessageKind } from '../types.js'
+import type { ResourceMetadata, MessageModel, OfferingData, ResourceModel, MessageKind } from '../types.js'
 import type { DataResponse, ErrorDetail, ErrorResponse, HttpResponse } from './types.js'
 import type { PrivateKeyJwk as Web5PrivateKeyJwk } from '@web5/crypto'
 
@@ -27,9 +27,9 @@ export type GetOfferingsOptions = {
   pfiDid: string
   params?: {
     /** ISO 3166 currency code string */
-    baseCurrency: OfferingModel['baseCurrency']['currencyCode']
+    baseCurrency: OfferingData['baseCurrency']['currencyCode']
     /** ISO 3166 currency code string */
-    quoteCurrency: OfferingModel['baseCurrency']['currencyCode']
+    quoteCurrency: OfferingData['baseCurrency']['currencyCode']
     id: ResourceMetadata<any>['id']
   }
 }
@@ -77,8 +77,9 @@ export class PfiRestClient {
     let response: Response
     try {
       response = await fetch(apiRoute, {
-        method : 'POST',
-        body   : JSON.stringify(jsonMessage)
+        method  : 'POST',
+        headers : { 'content-type': 'application/json' },
+        body    : JSON.stringify(jsonMessage)
       })
     } catch(e) {
       throw new Error(`Failed to send message to ${pfiDid}. Error: ${e.message}`)
@@ -220,6 +221,10 @@ export class PfiRestClient {
    *              when dereferencing the signer's DID
    */
   static async generateRequestToken(privateKeyJwk: Web5PrivateKeyJwk, kid: string): Promise<string> {
+    // TODO: include exp property. expires 1 minute from generation time
+    // TODO: include aud property. should be DID of receipient
+    // TODO: include nbf property. not before current time
+    // TODO: include iss property. should be requester's did
     const tokenPayload = { timestamp: new Date().toISOString() }
     return Crypto.sign({ privateKeyJwk, kid, payload: tokenPayload })
   }

--- a/js/src/resource-kinds/offering.ts
+++ b/js/src/resource-kinds/offering.ts
@@ -55,8 +55,8 @@ export class Offering extends Resource<'offering'> {
     return this.data.payoutMethods
   }
 
-  /** PresentationDefinition that describes the credential(s) the PFI requires in order to provide a quote. */
-  get vcRequirements() {
-    return this.data.vcRequirements
+  /** Articulates the claim(s) required when submitting an RFQ for this offering. */
+  get requiredClaims() {
+    return this.data.requiredClaims
   }
 }

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -29,7 +29,7 @@ export type ResourceMetadata<T extends ResourceKind> = {
 export type ResourceKind = keyof ResourceKinds
 export type ResourceKindModel<T extends ResourceKind> = ResourceKinds[T]
 export type ResourceKinds = {
-  'offering': OfferingModel
+  'offering': OfferingData
 }
 
 /**
@@ -37,7 +37,7 @@ export type ResourceKinds = {
  * including the requirements, conditions, and constraints in
  * order to fulfill that offer.
  */
-export type OfferingModel = {
+export type OfferingData = {
   /** Brief description of what is being offered. */
   description: string
   /** Number of quote currency units for one base currency unit (i.e 290000 USD for 1 BTC) */
@@ -50,8 +50,8 @@ export type OfferingModel = {
   payinMethods: PaymentMethod[]
   /** A list of accepted payment methods that Alice can use to receive baseCurrency from a PFI */
   payoutMethods: PaymentMethod[]
-  /** PresentationDefinition that describes the credential(s) the PFI requires in order to provide a quote. */
-  vcRequirements: PresentationDefinitionV2
+  /** Articulates the claim(s) required when submitting an RFQ for this offering. */
+  requiredClaims: PresentationDefinitionV2
 }
 
 export type CurrencyDetails = {
@@ -98,14 +98,14 @@ export type Private = Record<string, any>
 export type MessageKindModel<T extends keyof MessageKinds> = MessageKinds[T]
 export type MessageKind = 'rfq' | 'quote' | 'order' | 'orderstatus' | 'close'
 export type MessageKinds = {
-  'rfq': RfqModel
-  'quote': QuoteModel
-  'order': OrderModel
-  'orderstatus': OrderStatusModel
-  'close': CloseModel
+  'rfq': RfqData
+  'quote': QuoteData
+  'order': OrderData
+  'orderstatus': OrderStatusData
+  'close': CloseData
 }
 
-export type RfqModel = {
+export type RfqData = {
   /** Offering which Alice would like to get a quote for */
   offeringId: string
   /** Amount of quote currency you want to spend in order to receive base currency */
@@ -114,8 +114,8 @@ export type RfqModel = {
   payinMethod: SelectedPaymentMethod
   /** Selected payment method that the PFI will use to send the listed base currency to Alice */
   payoutMethod: SelectedPaymentMethod
-  /** Presentation Submission that fulfills the requirements included in the respective Offering */
-  vcs: string
+  /** claims that fulfill the requirements declared in an Offering */
+  claims: string[]
 }
 
 export type SelectedPaymentMethod = {
@@ -129,7 +129,7 @@ export type SelectedPaymentMethod = {
  * Message sent by the PFI in response to an RFQ. Includes a locked-in price that the PFI is willing to honor until
  * the quote expires
  */
-export type QuoteModel = {
+export type QuoteData = {
   /** When this quote expires. Expressed as ISO8601 */
   expiresAt: string
   /** the amount of base currency that Alice will receive */
@@ -166,7 +166,7 @@ export type PaymentInstruction = {
 /**
  * Message sent by Alice to the PFI to accept a Quote. Order is currently an empty object
  */
-export type OrderModel = {
+export type OrderData = {
   [key: string]: never
 }
 
@@ -174,7 +174,7 @@ export type OrderModel = {
  * Message sent by the PFI to Alice to convey the current status of an order. There can be many OrderStatus
  * messages in a given Exchange
  */
-export type OrderStatusModel = {
+export type OrderStatusData = {
   /** Current status of Order that's being executed (e.g. PROCESSING, COMPLETED, FAILED etc.) */
   orderStatus: string
 }
@@ -182,7 +182,7 @@ export type OrderStatusModel = {
 /**
  * a Close can be sent by Alice or the PFI as a reply to an RFQ or a Quote
  */
-export type CloseModel = {
+export type CloseData = {
   /** an explanation of why the exchange is being closed */
   reason?: string
 }

--- a/js/tests/offering.spec.ts
+++ b/js/tests/offering.spec.ts
@@ -1,11 +1,11 @@
-import type { OfferingModel } from '../src/main.js'
+import type { OfferingData } from '../src/main.js'
 
 import { Offering } from '../src/main.js'
 import { DevTools } from '../src/dev-tools.js'
 import { Convert } from '@web5/common'
 import { expect } from 'chai'
 
-const offeringData: OfferingModel = {
+const offeringData: OfferingData = {
   description  : 'Selling BTC for USD',
   baseCurrency : {
     currencyCode : 'BTC',
@@ -62,7 +62,7 @@ const offeringData: OfferingModel = {
       additionalProperties : false
     }
   }],
-  vcRequirements: {
+  requiredClaims: {
     id                : '7ce4004c-3c38-4853-968b-e411bafcd945',
     input_descriptors : [{
       id          : 'bbdb9b7c-5754-4f46-b63b-590bada959e0',

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -5,19 +5,20 @@
       "DOM",
       "ES6"
     ],
+    "rootDir": "./",
     "allowJs": true,
     "target": "esnext",
-    "module": "esnext",
+    "module": "nodenext",
     "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
-    "moduleResolution": "NodeNext",
+    "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
   "include": [
-    "./src"
+    "src"
   ],
   "exclude": [
     "node_modules",

--- a/json-schemas/offering.schema.json
+++ b/json-schemas/offering.schema.json
@@ -63,7 +63,7 @@
         "$ref": "#/definitions/PaymentMethod"
       }
     },
-    "vcRequirements": {
+    "requiredClaims": {
       "type": "object",
       "description": "PresentationDefinition that describes the credential(s) the PFI requires in order to provide a quote."
     }
@@ -75,6 +75,6 @@
     "quoteCurrency",
     "payinMethods",
     "payoutMethods",
-    "vcRequirements"
+    "requiredClaims"
   ]
 }

--- a/json-schemas/rfq.schema.json
+++ b/json-schemas/rfq.schema.json
@@ -27,8 +27,11 @@
       "type": "string",
       "description": "Amount of quote currency you want to spend in order to receive base currency"
     },
-    "vcs": {
-      "type": "string",
+    "claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
       "description": "Presentation Submission that fulfills the requirements included in the respective Offering"
     },
     "payinMethod": {
@@ -38,5 +41,5 @@
       "$ref": "#/definitions/SelectedPaymentMethod"
     }
   },
-  "required": ["offeringId", "quoteAmountSubunits", "vcs", "payinMethod", "payoutMethod"]
+  "required": ["offeringId", "quoteAmountSubunits", "claims", "payinMethod", "payoutMethod"]
 }


### PR DESCRIPTION
* Changed `Offering.vcRequirements` to `Offering.requiredClaims`.
    * Rationale:
        *  consistency. we have a property named `requiredPaymentDetails` so it made sense to put the word `required` first
        * `claims` is a more general term used in the identity management space. Specifically, OAuth, OpenID Connect, SAML
* Changed `Rfq.vcs` to `Rfq.claims` to match the above change
* `Rfq.claims` is now an an array of strings instead of a string. Prior to this PR, `Rfq.vcs` was expected to be a Verifiable Presentation JWT with a payload that included `presentation_submission` and `verifiableCredential`.  Decided that the signature is redundant because the RFQ itself is signed. Also, realized that `presentation_submission` isn't necessary (at the moment) to evaluate the provided credentials against an offering's requirements
* added tests for `Rfq.verifyClaims`